### PR TITLE
feat: add `ion template inspect` command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 publish = false
 authors = ["Roger Luo <rogerluo.rl18@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion"
-version = "0.1.15"
+version = "0.1.14"
 edition = "2021"
 publish = false
 authors = ["Roger Luo <rogerluo.rl18@gmail.com>"]

--- a/src/bin/ion/commands/template.rs
+++ b/src/bin/ion/commands/template.rs
@@ -1,6 +1,8 @@
 use clap::parser::ArgMatches;
-use clap::Command;
-use ion::blueprints::list_templates;
+use clap::{arg, Command};
+use ion::blueprints::{
+    ask_inspect_template, inspect_all_templates, inspect_template, list_templates,
+};
 use ion::config::Config;
 use ion::errors::CliResult;
 use ion::template::RemoteTemplate;
@@ -10,6 +12,12 @@ pub fn cli() -> Command {
         .about("template management")
         .subcommand(Command::new("list").about("list all available templates"))
         .subcommand(Command::new("update").about("update the templates from registry"))
+        .subcommand(
+            Command::new("inspect")
+                .about("inspect the contents of a template")
+                .arg(arg!([TEMPLATE] "Selects which template to print out"))
+                .arg(arg!(--"all" "Inspect all installed templates")),
+        )
         .arg_required_else_help(true)
 }
 
@@ -18,6 +26,21 @@ pub fn exec(config: &mut Config, matches: &ArgMatches) -> CliResult {
         Some(("list", _)) => list_templates(config)?,
         Some(("update", _)) => {
             RemoteTemplate::new(config).download()?;
+        }
+        Some(("inspect", matches)) => {
+            // Iff a template name is provided, inspect template; otherwise, check for --all flag; if no --all, ask user to select template from list
+
+            match matches.get_one::<String>("TEMPLATE") {
+                Some(template) => inspect_template(config, template.to_owned())?,
+                None => {
+                    let all_flag = matches.get_flag("all");
+                    if all_flag {
+                        inspect_all_templates(config)?;
+                    } else {
+                        ask_inspect_template(config)?;
+                    }
+                }
+            };
         }
         _ => unreachable!(),
     }

--- a/src/ion/blueprints/utils.rs
+++ b/src/ion/blueprints/utils.rs
@@ -206,13 +206,12 @@ pub fn ask_inspect_template(config: &Config) -> Result<()> {
     let template_name = Select::with_theme(&ColorfulTheme::default())
         .items(&selection_options)
         .default(1)
-        .interact_opt()
-        .unwrap();
+        .interact_opt()?;
 
-    match template_name {
-        Some(index) => inspect_template(config, selection_options[index].to_owned())?,
-        _ => unreachable!(),
-    }
+    if let Some(template_name) = template_name {
+        inspect_template(config, selection_options[template_name].to_owned())?
+    };
+
     Ok(())
 }
 

--- a/src/ion/blueprints/utils.rs
+++ b/src/ion/blueprints/utils.rs
@@ -115,6 +115,8 @@ pub fn list_templates(config: &Config) -> Result<()> {
 pub fn inspect_template(config: &Config, template_name: String) -> Result<()> {
     let templates = config.template_dir().read_dir()?;
 
+    let mut template_found: bool = false;
+
     for entry in templates {
         let entry = match entry {
             Ok(e) => e,
@@ -134,9 +136,19 @@ pub fn inspect_template(config: &Config, template_name: String) -> Result<()> {
                 }
             };
             if template.name == template_name {
+                template_found = true;
                 println!("{}", source);
             }
         }
+    }
+
+    // If the template the user requested is not in the list of downloaded templates, ask user to select existing template to inspect
+    if !template_found {
+        println!(
+            "The {} template was not found.\nInstalled templates are:",
+            template_name
+        );
+        ask_inspect_template(config)?
     }
     Ok(())
 }

--- a/tests/bin/mod.rs
+++ b/tests/bin/mod.rs
@@ -3,6 +3,7 @@ pub mod clone;
 pub mod new;
 pub mod pkg;
 pub mod script;
+pub mod template;
 
 pub mod utils;
 pub use utils::*;

--- a/tests/bin/template.rs
+++ b/tests/bin/template.rs
@@ -1,7 +1,8 @@
 use super::*;
+use anyhow::{Ok, Result};
 
 #[test]
-fn test_template() {
+fn test_template() -> Result<()> {
     Ion::new().arg("template").arg("list").assert().success();
 
     Ion::new().arg("template").arg("update").assert().success();
@@ -19,4 +20,27 @@ fn test_template() {
         .arg("package")
         .assert()
         .success();
+
+    // Test escape from input / Ctrl+C behaviour with `ion template inspect` (cf. ask_inspect_input fn)
+    let mut p = Ion::new()
+        .arg("template")
+        .arg("inspect")
+        .arg("nonce")
+        .spawn(Some(30_000))?;
+
+    p.send_control('c')?;
+    p.exp_eof()?;
+
+    Ok(())?;
+
+    // Test nonce input
+    let mut ps = Ion::new()
+        .arg("template")
+        .arg("inspect")
+        .arg("nonce")
+        .spawn(Some(5_000))?;
+
+    ps.exp_string("Installed templates are:")?;
+
+    Ok(())
 }

--- a/tests/bin/template.rs
+++ b/tests/bin/template.rs
@@ -19,4 +19,11 @@ fn test_template() {
         .arg("package")
         .assert()
         .success();
+
+    Ion::new()
+        .arg("template")
+        .arg("inspect")
+        .arg("nonce")
+        .assert()
+        .success();
 }

--- a/tests/bin/template.rs
+++ b/tests/bin/template.rs
@@ -19,11 +19,4 @@ fn test_template() {
         .arg("package")
         .assert()
         .success();
-
-    Ion::new()
-        .arg("template")
-        .arg("inspect")
-        .arg("nonce")
-        .assert()
-        .success();
 }

--- a/tests/bin/template.rs
+++ b/tests/bin/template.rs
@@ -42,5 +42,10 @@ fn test_template() -> Result<()> {
 
     ps.exp_string("Installed templates are:")?;
 
+    // Send <ENTER> keycode to pty
+    ps.send_control('j')?;
+    ps.exp_string("name")?;
+    ps.exp_eof()?;
+
     Ok(())
 }

--- a/tests/bin/template.rs
+++ b/tests/bin/template.rs
@@ -1,0 +1,22 @@
+use super::*;
+
+#[test]
+fn test_template() {
+    Ion::new().arg("template").arg("list").assert().success();
+
+    Ion::new().arg("template").arg("update").assert().success();
+
+    Ion::new()
+        .arg("template")
+        .arg("inspect")
+        .arg("--all")
+        .assert()
+        .success();
+
+    Ion::new()
+        .arg("template")
+        .arg("inspect")
+        .arg("package")
+        .assert()
+        .success();
+}


### PR DESCRIPTION
The template command(s) have been tested and are working; hopefully the style somewhat keeps with the Ion repo.

You may want to check out the 'clone' tests, though - I'm getting intermittent failures with that test, and can't figure out why yet (nothing I did should've had any impact on the bin::clone::test_clone test). Just thought you should know, if you weren't already aware...

Closes issue: https://github.com/Roger-luo/Ion/issues/9#issue-1584769565

NB: updates have been made to deal with the non-happy-path; as of now, if the template the user wants to inspect does not exist in the list of templates installed, Ion will present a list of installed templates for the user to choose from..