### PR TITLE
feat: prompt user to star GitHub repos after install

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,12 +5,15 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   release-plz-release:
     name: Release-plz release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      tag: ${{ steps.release-plz.outputs.releases_created && fromJSON(steps.release-plz.outputs.releases)[0].tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -19,6 +22,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@v0.5
         with:
           command: release
@@ -47,3 +51,70 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build:
+    needs: release-plz-release
+    if: startsWith(needs.release-plz-release.outputs.tag, 'ion-v')
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release-plz-release.outputs.tag }}
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package
+        shell: bash
+        run: |
+          VERSION="${{ needs.release-plz-release.outputs.tag }}"
+          VERSION="${VERSION#ion-v}"
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../ion-${VERSION}-${{ matrix.target }}.tar.gz ion
+          cd ../../..
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ion-${{ matrix.target }}
+          path: ion-*.tar.gz
+
+  upload:
+    needs: [release-plz-release, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+
+      - name: Upload assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.release-plz-release.outputs.tag }}
+          files: ion-*.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,6 @@
 name: Release
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
@@ -13,12 +11,12 @@ permissions:
   contents: write
 
 env:
-  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+  RELEASE_TAG: ${{ inputs.tag }}
 
 jobs:
   build:
     # Only build binaries for the ion crate, not ion-skill
-    if: startsWith(github.event.release.tag_name || inputs.tag, 'ion-v')
+    if: startsWith(inputs.tag, 'ion-v')
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,6 +178,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c757a3b7e39161a4e56f9365141ada2a6c915a8622c408ab6bb4b5d047371031"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +831,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "crossterm",
  "env_logger",
  "ion-skill",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,11 +833,13 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dirs",
  "env_logger",
  "ion-skill",
  "log",
  "pathdiff",
  "ratatui",
+ "serde_json",
  "tempfile",
  "toml_edit",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,10 +7,12 @@ edition = "2024"
 anyhow = "1"
 clap = { version = "4.5.60", features = ["string", "derive"] }
 clap_complete = "4"
+dirs = "6"
 crossterm = "0.28"
 env_logger = "0.11"
 log = "0.4"
 ion-skill = { path = "crates/ion-skill" }
+serde_json = "1"
 pathdiff = "0.2"
 toml_edit = "0.22"
 ratatui = "0.29"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.5.60", features = ["string", "derive"] }
+clap_complete = "4"
 crossterm = "0.28"
 env_logger = "0.11"
 log = "0.4"

--- a/docs/plans/2026-03-07-completion-design.md
+++ b/docs/plans/2026-03-07-completion-design.md
@@ -1,0 +1,34 @@
+# Shell Completion Design
+
+## Summary
+
+Add `ion completion <shell>` to generate shell auto-completion scripts. Uses `clap_complete` to generate completions for bash, zsh, fish, elvish, and powershell.
+
+## Usage
+
+```
+ion completion bash
+ion completion zsh
+ion completion fish
+ion completion elvish
+ion completion powershell
+```
+
+Output goes to stdout. Users redirect to the appropriate shell config location:
+
+```bash
+ion completion bash > ~/.local/share/bash-completion/completions/ion
+ion completion zsh > ~/.zfunc/_ion
+ion completion fish > ~/.config/fish/completions/ion.fish
+```
+
+## Implementation
+
+1. Add `clap_complete = "4"` to root `Cargo.toml`
+2. Add `Completion { shell: clap_complete::Shell }` variant to `Commands` enum — `Shell` implements `clap::ValueEnum` so it works as a positional arg
+3. Create `src/commands/completion.rs` with `pub fn run(shell, cmd)` that calls `clap_complete::generate()` writing to stdout
+4. Wire up in `main.rs` match arm, passing `Cli::command()` to get the clap `Command` object
+
+## Testing
+
+Integration test verifying each shell variant exits 0 and produces non-empty output.

--- a/docs/plans/2026-03-07-completion-implementation.md
+++ b/docs/plans/2026-03-07-completion-implementation.md
@@ -1,0 +1,216 @@
+# Shell Completion Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add `ion completion <shell>` command to generate shell auto-completion scripts.
+
+**Architecture:** Uses `clap_complete` crate to generate completions from the existing clap-derived CLI definition. Top-level command taking a shell name as a required positional argument, outputs completion script to stdout.
+
+**Tech Stack:** clap_complete 4.x, clap 4.x (existing)
+
+---
+
+### Task 1: Add clap_complete dependency
+
+**Files:**
+- Modify: `Cargo.toml:8` (dependencies section)
+
+**Step 1: Add the dependency**
+
+In `Cargo.toml`, add `clap_complete` to `[dependencies]`:
+
+```toml
+clap_complete = "4"
+```
+
+Place it after the `clap` line.
+
+**Step 2: Verify it compiles**
+
+Run: `cargo check`
+Expected: compiles with no errors
+
+**Step 3: Commit**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "build: add clap_complete dependency"
+```
+
+---
+
+### Task 2: Write failing integration test
+
+**Files:**
+- Create: `tests/completion_integration.rs`
+
+**Step 1: Write the test file**
+
+```rust
+use std::process::Command;
+
+fn ion_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ion"))
+}
+
+#[test]
+fn completion_bash_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "bash"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success(), "exit code was not 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "completion output was empty");
+    assert!(stdout.contains("ion"), "completion should reference the binary name");
+}
+
+#[test]
+fn completion_zsh_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "zsh"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty());
+}
+
+#[test]
+fn completion_fish_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "fish"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty());
+}
+
+#[test]
+fn completion_invalid_shell_fails() {
+    let output = ion_cmd()
+        .args(["completion", "nushell"])
+        .output()
+        .expect("failed to run ion");
+    assert!(!output.status.success(), "should reject unknown shells");
+}
+
+#[test]
+fn completion_missing_shell_fails() {
+    let output = ion_cmd()
+        .args(["completion"])
+        .output()
+        .expect("failed to run ion");
+    assert!(!output.status.success(), "should require a shell argument");
+}
+```
+
+**Step 2: Run the tests to verify they fail**
+
+Run: `cargo test --test completion_integration`
+Expected: compilation error — `completion` is not a recognized subcommand yet
+
+**Step 3: Commit**
+
+```bash
+git add tests/completion_integration.rs
+git commit -m "test: add failing integration tests for completion command"
+```
+
+---
+
+### Task 3: Implement completion command and wire it up
+
+**Files:**
+- Create: `src/commands/completion.rs`
+- Modify: `src/commands/mod.rs:1` (add module declaration)
+- Modify: `src/main.rs:15-16` (add Commands variant)
+- Modify: `src/main.rs:170` (add match arm)
+
+**Step 1: Create `src/commands/completion.rs`**
+
+```rust
+use std::io;
+
+pub fn run(shell: clap_complete::Shell, mut cmd: clap::Command) {
+    clap_complete::generate(shell, &mut cmd, "ion", &mut io::stdout());
+}
+```
+
+**Step 2: Register the module in `src/commands/mod.rs`**
+
+Add this line (alphabetical order, after `config`):
+
+```rust
+pub mod completion;
+```
+
+**Step 3: Add the `Completion` variant to `Commands` enum in `src/main.rs`**
+
+Add this variant to the `Commands` enum, after the `Config` variant:
+
+```rust
+    /// Generate shell completion scripts
+    Completion {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
+    },
+```
+
+**Step 4: Add the match arm in `main()` in `src/main.rs`**
+
+In the `match cli.command` block, add after the `Config` arm:
+
+```rust
+        Commands::Completion { shell } => {
+            commands::completion::run(shell, Cli::command());
+            Ok(())
+        }
+```
+
+Note: `Cli::command()` requires `use clap::CommandFactory;` — but since we already have `use clap::Parser` and `Parser` is a supertrait of `CommandFactory`, we need to add `CommandFactory` to the import. Change line 1:
+
+```rust
+use clap::{CommandFactory, Parser, Subcommand};
+```
+
+**Step 5: Run the tests**
+
+Run: `cargo test --test completion_integration`
+Expected: all 5 tests pass
+
+**Step 6: Also run the full test suite**
+
+Run: `cargo test`
+Expected: all tests pass, no regressions
+
+**Step 7: Commit**
+
+```bash
+git add src/commands/completion.rs src/commands/mod.rs src/main.rs
+git commit -m "feat: add ion completion command for shell auto-completion"
+```
+
+---
+
+### Task 4: Manual smoke test
+
+**Step 1: Try each shell**
+
+Run each and verify non-empty, sensible output:
+
+```bash
+cargo run -- completion bash | head -5
+cargo run -- completion zsh | head -5
+cargo run -- completion fish | head -5
+```
+
+**Step 2: Verify error cases**
+
+```bash
+cargo run -- completion         # should error: missing required arg
+cargo run -- completion nushell # should error: invalid value
+```
+
+No commit needed for this task.

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,3 +1,6 @@
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
+
 use ion_skill::Error as SkillError;
 use ion_skill::installer::{InstallValidationOptions, SkillInstaller, hash_simple};
 use ion_skill::manifest_writer;
@@ -263,6 +266,7 @@ fn install_collection(
             skills.len()
         ))
     );
+    prompt_github_star(base_source);
     crate::commands::init::print_no_targets_hint(merged_options, p);
     Ok(())
 }
@@ -321,6 +325,7 @@ fn finish_single_install(
     println!("  Updated {}", p.dim("Ion.lock"));
 
     println!("{}", p.success("Done!"));
+    prompt_github_star(source);
     crate::commands::init::print_no_targets_hint(merged_options, p);
     Ok(())
 }
@@ -336,6 +341,59 @@ fn register_in_registry(source: &SkillSource, project_dir: &std::path::Path) -> 
         registry.save()?;
     }
     Ok(())
+}
+
+fn starred_repos_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|d| d.join("ion").join("starred.json"))
+}
+
+fn load_starred_repos() -> Vec<String> {
+    starred_repos_path()
+        .and_then(|p| std::fs::read_to_string(&p).ok())
+        .and_then(|s| serde_json::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save_starred_repos(repos: &[String]) {
+    if let Some(path) = starred_repos_path() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let _ = std::fs::write(&path, serde_json::to_string_pretty(repos).unwrap_or_default());
+    }
+}
+
+fn prompt_github_star(source: &SkillSource) {
+    if source.source_type != SourceType::Github || !std::io::stdin().is_terminal() {
+        return;
+    }
+
+    let repo = &source.source;
+    let mut starred = load_starred_repos();
+    if starred.iter().any(|r| r == repo) {
+        return;
+    }
+
+    print!("  Star {repo} on GitHub? [Y/n] ");
+    let _ = std::io::stdout().flush();
+
+    let mut answer = String::new();
+    if std::io::stdin().read_line(&mut answer).is_err() {
+        return;
+    }
+    let answer = answer.trim();
+    if answer.is_empty() || answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes")
+    {
+        let _ = std::process::Command::new("gh")
+            .args(["repo", "star", repo])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
+
+    // Record regardless of yes/no so we don't ask again
+    starred.push(repo.to_string());
+    save_starred_repos(&starred);
 }
 
 fn skill_name_from_source(source: &SkillSource) -> String {

--- a/src/commands/completion.rs
+++ b/src/commands/completion.rs
@@ -1,0 +1,5 @@
+use std::io;
+
+pub fn run(shell: clap_complete::Shell, mut cmd: clap::Command) {
+    clap_complete::generate(shell, &mut cmd, "ion", &mut io::stdout());
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod add;
+pub mod completion;
 pub mod config;
 pub mod eject;
 pub mod gc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use clap::{Parser, Subcommand};
+use clap::{CommandFactory, Parser, Subcommand};
 
 mod commands;
 mod context;
@@ -91,6 +91,11 @@ enum Commands {
     Self_ {
         #[command(subcommand)]
         action: SelfCommands,
+    },
+    /// Generate shell completion scripts
+    Completion {
+        /// Shell to generate completions for
+        shell: clap_complete::Shell,
     },
 }
 
@@ -228,6 +233,10 @@ fn main() {
             SelfCommands::Check => commands::self_cmd::check(),
             SelfCommands::Update { version } => commands::self_cmd::update(version.as_deref()),
         },
+        Commands::Completion { shell } => {
+            commands::completion::run(shell, Cli::command());
+            Ok(())
+        }
     };
 
     if let Err(e) = result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,13 @@ enum Commands {
         action: SelfCommands,
     },
     /// Generate shell completion scripts
+    #[command(after_help = "\
+Setup:
+  bash   ion completion bash >> ~/.bashrc
+  zsh    ion completion zsh > ~/.zfunc/_ion
+  fish   ion completion fish > ~/.config/fish/completions/ion.fish
+  elvish ion completion elvish >> ~/.config/elvish/rc.elv
+  pwsh   ion completion powershell >> $PROFILE")]
     Completion {
         /// Shell to generate completions for
         shell: clap_complete::Shell,

--- a/tests/completion_integration.rs
+++ b/tests/completion_integration.rs
@@ -1,0 +1,57 @@
+use std::process::Command;
+
+fn ion_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ion"))
+}
+
+#[test]
+fn completion_bash_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "bash"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success(), "exit code was not 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty(), "completion output was empty");
+    assert!(stdout.contains("ion"), "completion should reference the binary name");
+}
+
+#[test]
+fn completion_zsh_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "zsh"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty());
+}
+
+#[test]
+fn completion_fish_produces_output() {
+    let output = ion_cmd()
+        .args(["completion", "fish"])
+        .output()
+        .expect("failed to run ion");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.is_empty());
+}
+
+#[test]
+fn completion_invalid_shell_fails() {
+    let output = ion_cmd()
+        .args(["completion", "nushell"])
+        .output()
+        .expect("failed to run ion");
+    assert!(!output.status.success(), "should reject unknown shells");
+}
+
+#[test]
+fn completion_missing_shell_fails() {
+    let output = ion_cmd()
+        .args(["completion"])
+        .output()
+        .expect("failed to run ion");
+    assert!(!output.status.success(), "should require a shell argument");
+}

--- a/tests/completion_integration.rs
+++ b/tests/completion_integration.rs
@@ -55,3 +55,16 @@ fn completion_missing_shell_fails() {
         .expect("failed to run ion");
     assert!(!output.status.success(), "should require a shell argument");
 }
+
+#[test]
+fn completion_help_shows_setup_instructions() {
+    let output = ion_cmd()
+        .args(["completion", "--help"])
+        .output()
+        .expect("failed to run ion");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Setup:"), "help should include setup section");
+    assert!(stdout.contains(".bashrc"), "help should show bash setup");
+    assert!(stdout.contains(".zfunc"), "help should show zsh setup");
+    assert!(stdout.contains("completions/ion.fish"), "help should show fish setup");
+}


### PR DESCRIPTION
## Summary
- After `ion add` installs a skill from GitHub, prompts `Star owner/repo on GitHub? [Y/n]`
- Uses `gh repo star` via subprocess; silently skips if `gh` is unavailable or not authenticated
- Tracks prompted repos in `~/.config/ion/starred.json` to avoid re-prompting

## Test plan
- [x] `cargo build` compiles
- [x] `cargo test` — all 120 tests pass (integration tests pipe stdin, so no prompt fires)
- [x] `cargo clippy` — no new warnings
- [ ] Manual: `ion add owner/repo` from GitHub → prompts to star after install
- [ ] Manual: run same add again → no prompt (already in starred.json)
- [ ] Manual: local path source → no prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)