### PR TITLE
docs: add local dev workflow to ion-cli skill template

### DIFF
--- a/templates/ion-cli.md.j2
+++ b/templates/ion-cli.md.j2
@@ -189,6 +189,24 @@ $ ion add owner/mytool --name custom-name
 
 In Ion.toml: `mytool = { type = "binary", source = "owner/mytool", binary = "mytool" }`
 
+### Local development with binary skills
+
+To test a local checkout of a binary skill (e.g., after cloning a repo you normally install from
+GitHub), use `--dev` to point `ion run` at the source directory:
+
+```bash
+# Switch from remote to local dev
+$ ion add ./path/to/local-checkout --dev
+$ ion run mytool [args...]      # runs: cargo run -- [args]
+
+# Switch back to remote release
+$ ion add owner/mytool --bin
+```
+
+Dev mode forwards every `ion run` to `cargo run` in the source directory, so changes are picked
+up immediately without a rebuild step. This is the equivalent of `pip install -e .` for Rust
+binary skills.
+
 ### Developing a binary skill
 
 A binary skill project is a Cargo crate. Declare it in `Ion.toml`:


### PR DESCRIPTION
## Summary
- Fix `cargo_project_info` to scan all workspace member packages when the root package has no binary targets — previously `ion add --dev` failed on Cargo workspaces because it only checked the first package (typically a library crate)
- Add `raw_metadata()` to ionem's cargo module for callers that need the full workspace JSON
- Add a "Local development with binary skills" section to the ion-cli skill template explaining how to switch between remote and local dev mode

## Test plan
- [x] `cargo clippy` passes
- [x] All 305 tests pass
- [x] Verified `ion add /path/to/workspace --bin --dev` works against a real Cargo workspace (armitage — 7 crates, binary in a member crate)
- [x] Verified `ion run armitage -- --help` works through the dev path

🤖 Generated with [Claude Code](https://claude.com/claude-code)