### PR TITLE
fix: support Cargo workspaces in binary skill dev mode

### DIFF
--- a/crates/ion-skill/src/binary.rs
+++ b/crates/ion-skill/src/binary.rs
@@ -452,8 +452,9 @@ pub struct CargoProject {
 
 /// Run `cargo metadata` to extract binary name and version from a Cargo project.
 ///
-/// Finds the first `[[bin]]` target in the package. Errors if no binary target is found
-/// or if the path doesn't contain a valid Cargo project.
+/// Finds the first `[[bin]]` target in the package. For workspaces, scans all member
+/// packages if the root package has no binary targets. Errors if no binary target is
+/// found or if the path doesn't contain a valid Cargo project.
 pub fn cargo_project_info(project_path: &Path) -> crate::Result<CargoProject> {
     let manifest_path = project_path.join("Cargo.toml");
     if !manifest_path.exists() {
@@ -464,21 +465,57 @@ pub fn cargo_project_info(project_path: &Path) -> crate::Result<CargoProject> {
     }
 
     let meta = ionem::shell::cargo::project(&manifest_path).metadata()?;
-    let binary_name = meta
-        .binary_targets
-        .first()
-        .ok_or_else(|| {
-            crate::Error::Other(format!(
-                "No binary target found in {}. Is this a binary crate?",
-                project_path.display()
-            ))
-        })?
-        .clone();
+    if let Some(binary_name) = meta.binary_targets.first() {
+        return Ok(CargoProject {
+            binary_name: binary_name.clone(),
+            version: meta.version,
+        });
+    }
 
-    Ok(CargoProject {
-        binary_name,
-        version: meta.version,
-    })
+    // No binary target in the default package — scan all workspace members.
+    if let Some(result) = find_workspace_binary(&manifest_path)? {
+        return Ok(result);
+    }
+
+    Err(crate::Error::Other(format!(
+        "No binary target found in {}. Is this a binary crate?",
+        project_path.display()
+    )))
+}
+
+/// Scan all packages in a cargo workspace for the first binary target.
+fn find_workspace_binary(manifest_path: &Path) -> crate::Result<Option<CargoProject>> {
+    let json_str = ionem::shell::cargo::raw_metadata(manifest_path)
+        .map_err(|e| crate::Error::Other(format!("Failed to run cargo metadata: {e}")))?;
+
+    let json: serde_json::Value = serde_json::from_str(&json_str)
+        .map_err(|e| crate::Error::Other(format!("Failed to parse cargo metadata: {e}")))?;
+
+    let packages = match json["packages"].as_array() {
+        Some(pkgs) => pkgs,
+        None => return Ok(None),
+    };
+
+    for package in packages {
+        let targets = match package["targets"].as_array() {
+            Some(t) => t,
+            None => continue,
+        };
+        for target in targets {
+            let is_bin = target["kind"]
+                .as_array()
+                .is_some_and(|kinds| kinds.iter().any(|k| k.as_str() == Some("bin")));
+            if is_bin && let Some(name) = target["name"].as_str() {
+                let version = package["version"].as_str().unwrap_or("0.0.0").to_string();
+                return Ok(Some(CargoProject {
+                    binary_name: name.to_string(),
+                    version,
+                }));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 /// Build a local Cargo project in release mode and install the binary.

--- a/crates/ionem/src/shell/cargo.rs
+++ b/crates/ionem/src/shell/cargo.rs
@@ -56,6 +56,22 @@ pub struct CargoMetadata {
     pub manifest_path: String,
 }
 
+/// Run `cargo metadata --no-deps` and return the raw JSON string.
+/// Useful when callers need to inspect all workspace packages directly.
+pub fn raw_metadata(manifest_path: &Path) -> Result<String> {
+    CLI.run_command(
+        CLI.command()
+            .args([
+                "metadata",
+                "--no-deps",
+                "--format-version",
+                "1",
+                "--manifest-path",
+            ])
+            .arg(manifest_path),
+    )
+}
+
 /// Run `cargo metadata --no-deps` and parse the result.
 /// `manifest_path` should point to the Cargo.toml file.
 pub fn metadata(manifest_path: &Path) -> Result<CargoMetadata> {


### PR DESCRIPTION
## Summary
- Fix `cargo_project_info` to scan all workspace member packages when the root package has no binary targets
- Previously `ion add --dev` failed on Cargo workspaces because it only checked the first package returned by `cargo metadata`, which was typically a library crate
- Add `raw_metadata()` to ionem's cargo module for callers that need the full workspace JSON

## Test plan
- [x] `cargo clippy` passes
- [x] All 305 tests pass
- [x] Verified `ion add /path/to/workspace --bin --dev` works against a real Cargo workspace (armitage — 7 crates, binary in a member crate)
- [x] Verified `ion run armitage -- --help` works through the dev path

🤖 Generated with [Claude Code](https://claude.com/claude-code)