### PR TITLE
feat: add built-in AGENTS.md templates for common project types

### DIFF
--- a/crates/ion-skill/src/agents.rs
+++ b/crates/ion-skill/src/agents.rs
@@ -172,16 +172,35 @@ pub struct FetchedTemplate {
     pub checksum: String,
 }
 
+/// Return a `FetchedTemplate` from an embedded built-in template.
+pub fn fetch_builtin_template(name: &str) -> Result<FetchedTemplate> {
+    let content = crate::templates::get(name)
+        .ok_or_else(|| Error::Other(format!("Unknown built-in template: {name}")))?;
+    let checksum = checksum_content(content.as_bytes());
+    Ok(FetchedTemplate {
+        content: content.to_string(),
+        rev: None,
+        checksum,
+    })
+}
+
 /// Fetch an AGENTS.md template from a source.
 ///
 /// Resolves the source using SkillSource::infer, fetches the repo/path,
 /// and extracts the AGENTS.md file at the specified path (default: root).
+/// Built-in templates (`builtin:rust`, etc.) are resolved from the binary
+/// without any network access.
 pub fn fetch_template(
     source_str: &str,
     rev: Option<&str>,
     file_path: Option<&str>,
     _project_dir: &Path,
 ) -> Result<FetchedTemplate> {
+    // Built-in templates are resolved from the binary directly.
+    if let Some(name) = crate::templates::parse_builtin_name(source_str) {
+        return fetch_builtin_template(name);
+    }
+
     let mut source = SkillSource::infer(source_str)?;
     if let Some(r) = rev {
         source.rev = Some(r.to_string());

--- a/crates/ion-skill/src/lib.rs
+++ b/crates/ion-skill/src/lib.rs
@@ -13,6 +13,7 @@ pub mod registry;
 pub mod search;
 pub mod skill;
 pub mod source;
+pub mod templates;
 pub mod update;
 pub mod validate;
 pub mod workspace;

--- a/crates/ion-skill/src/templates.rs
+++ b/crates/ion-skill/src/templates.rs
@@ -1,0 +1,93 @@
+//! Built-in AGENTS.md templates shipped with the ion binary.
+//!
+//! These templates provide offline project scaffolding for common language
+//! ecosystems. When ion is updated, the embedded templates update too —
+//! `ion agents update` will detect the new content via checksum comparison.
+
+/// Prefix used to identify built-in templates in Ion.toml and the CLI.
+pub const BUILTIN_PREFIX: &str = "builtin:";
+
+/// List of available built-in template names.
+pub const AVAILABLE: &[&str] = &["rust", "python", "julia", "rust+python"];
+
+/// Return the embedded template content for a given name, or `None` if unknown.
+pub fn get(name: &str) -> Option<&'static str> {
+    match name {
+        "rust" => Some(include_str!("templates/rust.md")),
+        "python" => Some(include_str!("templates/python.md")),
+        "julia" => Some(include_str!("templates/julia.md")),
+        "rust+python" | "rust-python" => Some(include_str!("templates/rust-python.md")),
+        _ => None,
+    }
+}
+
+/// Parse a source string into a built-in template name if it matches.
+///
+/// Only the `builtin:` prefix is recognized (e.g. `builtin:rust`).
+/// Bare names like `rust` are treated as remote sources to avoid
+/// ambiguity with source aliases.
+/// Returns `None` if the source doesn't refer to a known built-in template.
+pub fn parse_builtin_name(source: &str) -> Option<&str> {
+    let name = source.strip_prefix(BUILTIN_PREFIX)?;
+    if get(name).is_some() {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_known_templates() {
+        assert!(get("rust").is_some());
+        assert!(get("python").is_some());
+        assert!(get("julia").is_some());
+        assert!(get("rust+python").is_some());
+        assert!(get("rust-python").is_some()); // alias
+    }
+
+    #[test]
+    fn get_unknown_returns_none() {
+        assert!(get("go").is_none());
+        assert!(get("").is_none());
+    }
+
+    #[test]
+    fn parse_prefixed_name() {
+        assert_eq!(parse_builtin_name("builtin:rust"), Some("rust"));
+        assert_eq!(parse_builtin_name("builtin:python"), Some("python"));
+        assert_eq!(parse_builtin_name("builtin:julia"), Some("julia"));
+        assert_eq!(
+            parse_builtin_name("builtin:rust+python"),
+            Some("rust+python")
+        );
+    }
+
+    #[test]
+    fn bare_name_is_not_builtin() {
+        assert_eq!(parse_builtin_name("rust"), None);
+        assert_eq!(parse_builtin_name("python"), None);
+    }
+
+    #[test]
+    fn parse_non_builtin_returns_none() {
+        assert_eq!(parse_builtin_name("org/repo"), None);
+        assert_eq!(parse_builtin_name("https://github.com/foo/bar"), None);
+        assert_eq!(parse_builtin_name("builtin:go"), None);
+    }
+
+    #[test]
+    fn templates_are_non_empty() {
+        for name in AVAILABLE {
+            let content = get(name).unwrap();
+            assert!(!content.is_empty(), "template {name} should not be empty");
+            assert!(
+                content.contains("# AGENTS.md"),
+                "template {name} should have AGENTS.md header"
+            );
+        }
+    }
+}

--- a/crates/ion-skill/src/templates/julia.md
+++ b/crates/ion-skill/src/templates/julia.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project
+
+<!-- Describe your project here -->
+
+## Build & Test Commands
+
+```bash
+julia --project -e 'using Pkg; Pkg.instantiate()'  # Install dependencies
+julia --project -e 'using Pkg; Pkg.test()'          # All tests
+julia --project -e 'include("test/runtests.jl")'    # Run tests directly
+```
+
+## Pre-commit Checklist
+
+**Run before committing:**
+
+```bash
+julia --project -e 'using JuliaFormatter; format("src")' # 1. Format
+julia --project -e 'using Pkg; Pkg.test()'                # 2. Test
+```
+
+## Project Structure
+
+- `Project.toml` -- project metadata and direct dependencies
+- `Manifest.toml` -- locked dependency versions
+- `src/` -- source code (main module file: `src/<PackageName>.jl`)
+- `test/` -- test files (`test/runtests.jl` is the entry point)
+
+## Architecture
+
+<!-- Describe your architecture here. Examples: -->
+<!-- - Module organization and exports -->
+<!-- - Key types and their relationships -->
+<!-- - Abstract types and their subtypes -->
+<!-- - Multiple dispatch patterns -->
+
+## Key Conventions
+
+- **Module structure:** One main module matching the package name, with sub-modules in `src/`
+- **Testing:** Tests live in `test/runtests.jl`, using the `Test` standard library
+- **Documentation:** Use docstrings above functions/types with triple-quoted strings
+
+## Git Conventions
+
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`, `perf:`, `build:`, `chore:`
+- **Breaking changes:** Use `feat!:` or `fix!:` (note the `!`) or add a `BREAKING CHANGE:` footer

--- a/crates/ion-skill/src/templates/python.md
+++ b/crates/ion-skill/src/templates/python.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project
+
+<!-- Describe your project here -->
+
+## Build & Test Commands
+
+```bash
+uv sync                                  # Install/update dependencies
+uv run pytest                            # All tests
+uv run pytest tests/test_name.py         # Single test file
+uv run pytest -k test_name               # Single test by name
+uv run ruff check .                      # Lint
+uv run ruff format .                     # Format
+```
+
+## Pre-commit Checklist
+
+**Run all three before committing:**
+
+```bash
+uv run ruff format .                     # 1. Format
+uv run ruff check . --fix                # 2. Lint (auto-fix where possible)
+uv run pytest                            # 3. Test
+```
+
+## Project Structure
+
+This project uses [uv](https://docs.astral.sh/uv/) for dependency and environment management.
+
+- `pyproject.toml` -- project metadata and dependencies
+- `uv.lock` -- locked dependency versions (committed to git)
+- `src/` -- source code
+- `tests/` -- test files
+
+## Architecture
+
+<!-- Describe your architecture here. Examples: -->
+<!-- - Package layout and module organization -->
+<!-- - Key classes/modules and their responsibilities -->
+<!-- - Core data types and their relationships -->
+<!-- - Important protocols/ABCs and their implementors -->
+
+## Key Conventions
+
+- **Python version:** >= 3.12
+- **Type hints:** Use type annotations for all public functions
+- **Dependency management:** Use `uv add <package>` to add dependencies, `uv add --dev <package>` for dev dependencies
+
+## Git Conventions
+
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`, `perf:`, `build:`, `chore:`
+- **Breaking changes:** Use `feat!:` or `fix!:` (note the `!`) or add a `BREAKING CHANGE:` footer

--- a/crates/ion-skill/src/templates/rust-python.md
+++ b/crates/ion-skill/src/templates/rust-python.md
@@ -1,0 +1,77 @@
+# AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project
+
+<!-- Describe your project here -->
+<!-- This is a mixed Rust + Python project, typically using PyO3/maturin for Rust-Python interop -->
+
+## Build & Test Commands
+
+### Rust
+
+```bash
+cargo build                              # Build Rust code
+cargo test                               # Rust tests
+cargo clippy                             # Lint Rust
+cargo fmt                                # Format Rust
+```
+
+### Python
+
+```bash
+uv sync                                  # Install/update Python dependencies
+uv run maturin develop                   # Build and install Rust extension in dev mode
+uv run pytest                            # Python tests
+uv run ruff check .                      # Lint Python
+uv run ruff format .                     # Format Python
+```
+
+## Pre-commit Checklist
+
+**Run all before committing:**
+
+```bash
+# Rust
+cargo fmt --all                                          # 1. Format Rust
+cargo clippy --all-targets --all-features -- -D warnings # 2. Lint Rust
+
+# Python
+uv run ruff format .                                     # 3. Format Python
+uv run ruff check . --fix                                # 4. Lint Python
+
+# Tests
+cargo test                                               # 5. Rust tests
+uv run maturin develop                                   # 6. Build extension
+uv run pytest                                            # 7. Python tests
+```
+
+## Project Structure
+
+- `Cargo.toml` -- Rust project metadata and dependencies
+- `pyproject.toml` -- Python project metadata and dependencies
+- `uv.lock` -- locked Python dependency versions
+- `src/` -- Rust source code (with PyO3 bindings)
+- `python/` -- Python source code
+- `tests/` -- Python tests
+
+## Architecture
+
+<!-- Describe your architecture here. Examples: -->
+<!-- - Rust crate layout and module organization -->
+<!-- - Python package structure -->
+<!-- - PyO3 binding layer and exposed API -->
+<!-- - Which logic lives in Rust vs Python -->
+
+## Key Conventions
+
+- **Rust edition:** 2024
+- **Python version:** >= 3.12
+- **Interop:** PyO3 with maturin for building
+- **Error handling:** Rust errors are converted to Python exceptions via PyO3
+
+## Git Conventions
+
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`, `perf:`, `build:`, `chore:`
+- **Breaking changes:** Use `feat!:` or `fix!:` (note the `!`) or add a `BREAKING CHANGE:` footer

--- a/crates/ion-skill/src/templates/rust.md
+++ b/crates/ion-skill/src/templates/rust.md
@@ -1,0 +1,45 @@
+# AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project
+
+<!-- Describe your project here -->
+
+## Build & Test Commands
+
+```bash
+cargo build                              # Dev build
+cargo test                               # All tests
+cargo test test_name                     # Single test by name
+cargo clippy                             # Lint
+cargo fmt                                # Format
+```
+
+## Pre-commit Checklist
+
+**Run all three before committing** — CI checks these exact commands:
+
+```bash
+cargo fmt --all                                          # 1. Format
+cargo clippy --all-targets --all-features -- -D warnings # 2. Lint (warnings are errors)
+cargo test                                               # 3. Test
+```
+
+## Architecture
+
+<!-- Describe your architecture here. Examples: -->
+<!-- - Crate layout (binary vs library, workspace members) -->
+<!-- - Key modules and their responsibilities -->
+<!-- - Core data types and their relationships -->
+<!-- - Important traits and their implementors -->
+
+## Key Conventions
+
+- **Error handling:** `anyhow::Result` for application code, `thiserror` for library errors
+- **Rust edition:** 2024
+
+## Git Conventions
+
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`, `perf:`, `build:`, `chore:`
+- **Breaking changes:** Use `feat!:` or `fix!:` (note the `!`) or add a `BREAKING CHANGE:` footer

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -108,11 +108,24 @@ pub fn init(
         );
     }
 
-    // Resolve source through global config aliases
-    let resolved_source = ws.global_config.resolve_source(source);
-
-    // Fetch template
-    let fetched = ion_skill::agents::fetch_template(&resolved_source, rev, path, &project.dir)?;
+    // Detect built-in templates and normalize the source name
+    let (fetched, canonical_source) = if let Some(name) =
+        ion_skill::templates::parse_builtin_name(source)
+    {
+        if rev.is_some() {
+            anyhow::bail!("--rev cannot be used with built-in templates");
+        }
+        if path.is_some() {
+            anyhow::bail!("--path cannot be used with built-in templates");
+        }
+        let fetched = ion_skill::agents::fetch_builtin_template(name)?;
+        let canonical = format!("builtin:{name}");
+        (fetched, canonical)
+    } else {
+        let resolved_source = ws.global_config.resolve_source(source);
+        let fetched = ion_skill::agents::fetch_template(&resolved_source, rev, path, &project.dir)?;
+        (fetched, source.to_string())
+    };
 
     let agents_md_path = project.dir.join("AGENTS.md");
     let upstream_dir = project.dir.join(".agents/templates");
@@ -140,12 +153,17 @@ pub fn init(
     }
 
     // Write [agents] to Ion.toml
-    ion_skill::manifest_writer::write_agents_config(&project.manifest_path, source, rev, path)?;
+    ion_skill::manifest_writer::write_agents_config(
+        &project.manifest_path,
+        &canonical_source,
+        rev,
+        path,
+    )?;
 
     // Write lock entry
     let mut lockfile = project.lockfile()?;
     lockfile.agents = Some(ion_skill::agents::AgentsLockEntry {
-        template: source.to_string(),
+        template: canonical_source.clone(),
         rev: fetched.rev,
         checksum: fetched.checksum,
         updated_at: ion_skill::agents::now_iso8601(),
@@ -178,7 +196,7 @@ pub fn init(
 
     if json {
         crate::json::print_success(serde_json::json!({
-            "template": source,
+            "template": canonical_source,
             "agents_md_created": !already_existed,
         }));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,9 +262,9 @@ enum WorkspaceCommands {
 
 #[derive(Subcommand)]
 enum AgentsCommands {
-    /// Set up AGENTS.md template sourcing from a remote repository
+    /// Set up AGENTS.md from a built-in template or remote repository
     Init {
-        /// Template source (e.g., org/repo, git URL, or local path)
+        /// Template source: builtin:<name> (rust, python, julia, rust+python), org/repo, git URL, or local path
         source: String,
         /// Pin to a specific git ref (branch, tag, or commit SHA)
         #[arg(long)]


### PR DESCRIPTION
## Summary

- Add offline built-in AGENTS.md templates for **rust**, **python** (uv), **julia**, and **rust+python** (PyO3/maturin) projects
- Templates are embedded in the binary via `include_str!` and require no network access: `ion agents init builtin:rust`
- The `builtin:` prefix is required to distinguish from remote sources (avoids shadowing source aliases)
- `ion agents update` and `ion agents diff` work automatically for builtin templates — when ion is updated with new template content, the checksum difference is detected and the upstream is staged

## Changes

- **New:** `crates/ion-skill/src/templates.rs` — module with `get()`, `parse_builtin_name()`, `AVAILABLE` list
- **New:** `crates/ion-skill/src/templates/*.md` — 4 template files (rust, python, julia, rust-python)
- **Modified:** `crates/ion-skill/src/agents.rs` — `fetch_builtin_template()` + builtin detection in `fetch_template()`
- **Modified:** `src/commands/agents.rs` — normalize builtin sources, reject `--rev`/`--path` for builtins
- **Modified:** `src/main.rs` — updated help text for `ion agents init`

## Test plan

- [x] All 305 existing tests pass
- [x] 6 new unit tests for template module (known/unknown templates, prefix parsing, bare name rejection)
- [x] Manual: `ion agents init builtin:rust` creates AGENTS.md from embedded template
- [x] Manual: `ion agents init builtin:python` works for Python/uv template
- [x] Manual: `ion agents init rust` is treated as remote source (not intercepted as builtin)
- [x] Manual: `ion agents init builtin:rust --rev main` errors with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)