### PR TITLE
fix: improve search ranking with skills.sh API and unified scoring

### DIFF
--- a/crates/ion-skill/src/search/github.rs
+++ b/crates/ion-skill/src/search/github.rs
@@ -155,47 +155,60 @@ impl SearchSource for GitHubSource {
         }
 
         // 3. Repo search: find repos whose name/description matches the query
-        log::debug!("github: repo search for {query:?}");
-        if let Ok(body) = gh
-            .search_repos(query)
-            .json(&["fullName", "description", "stargazersCount"])
-            .limit(10)
-            .run()
-            .map_err(|e| crate::Error::Search(e.to_string()))
-        {
-            let repo_results = parse_gh_repo_response(&body, 10)?;
-            log::debug!("github: repo search found {} repos", repo_results.len());
-            for repo in &repo_results {
-                if seen_sources.contains(&repo.source) {
-                    continue;
-                }
-                if looks_skill_related(repo) {
-                    let mut skills = enumerate_repo_skills(&repo.source, limit * 3, &seen_sources);
-                    if !skills.is_empty() {
-                        log::debug!(
-                            "github: enumerated {} skills in {}",
-                            skills.len(),
-                            repo.source
-                        );
-                        for r in &mut skills {
-                            if r.stars.is_none() {
-                                r.stars = repo.stars;
-                            }
-                        }
-                        for r in skills {
-                            seen_sources.insert(r.source.clone());
-                            results.push(r);
-                        }
-                    } else {
-                        log::debug!(
-                            "github: {} looks skill-related but has no SKILL.md, skipping",
-                            repo.source
-                        );
+        //    Also do a skill-focused search ("{query} skill") to surface skill
+        //    repos that would otherwise be drowned out by popular non-skill repos.
+        let repo_queries: Vec<String> = {
+            let mut qs = vec![query.to_string()];
+            let q_lower = query.to_lowercase();
+            if !q_lower.contains("skill") {
+                qs.push(format!("{query} skill"));
+            }
+            qs
+        };
+        for repo_query in &repo_queries {
+            log::debug!("github: repo search for {repo_query:?}");
+            if let Ok(body) = gh
+                .search_repos(repo_query)
+                .json(&["fullName", "description", "stargazersCount"])
+                .limit(10)
+                .run()
+                .map_err(|e| crate::Error::Search(e.to_string()))
+            {
+                let repo_results = parse_gh_repo_response(&body, 10)?;
+                log::debug!("github: repo search found {} repos", repo_results.len());
+                for repo in &repo_results {
+                    if seen_sources.contains(&repo.source) {
+                        continue;
                     }
-                    continue;
-                }
-                if seen_sources.insert(repo.source.clone()) && repo_has_skill_md(&repo.source) {
-                    results.push(repo.clone());
+                    if looks_skill_related(repo) {
+                        let mut skills =
+                            enumerate_repo_skills(&repo.source, limit * 3, &seen_sources);
+                        if !skills.is_empty() {
+                            log::debug!(
+                                "github: enumerated {} skills in {}",
+                                skills.len(),
+                                repo.source
+                            );
+                            for r in &mut skills {
+                                if r.stars.is_none() {
+                                    r.stars = repo.stars;
+                                }
+                            }
+                            for r in skills {
+                                seen_sources.insert(r.source.clone());
+                                results.push(r);
+                            }
+                        } else {
+                            log::debug!(
+                                "github: {} looks skill-related but has no SKILL.md, skipping",
+                                repo.source
+                            );
+                        }
+                        continue;
+                    }
+                    if seen_sources.insert(repo.source.clone()) && repo_has_skill_md(&repo.source) {
+                        results.push(repo.clone());
+                    }
                 }
             }
         }
@@ -221,6 +234,7 @@ fn looks_skill_related(result: &SearchResult) -> bool {
 }
 
 /// Enumerate individual skills in a GitHub repo by searching for SKILL.md files.
+/// Falls back to the Contents API when code search is rate-limited.
 fn enumerate_repo_skills(
     repo: &str,
     limit: usize,
@@ -237,7 +251,9 @@ fn enumerate_repo_skills(
         Ok(b) => b,
         Err(e) => {
             log::debug!("github: failed to enumerate {repo}: {e}");
-            return vec![];
+            // Code search may be rate-limited; fall back to the Contents API
+            // which uses a separate (much higher) rate limit.
+            return repo_has_root_skill_md(repo, seen);
         }
     };
     match parse_gh_code_response(&body, limit) {
@@ -252,19 +268,48 @@ fn enumerate_repo_skills(
     }
 }
 
+/// Check whether a repo has a SKILL.md at its root using the Contents API.
+/// This uses the REST API rate limit (5000/hr) instead of the code search
+/// rate limit (30/min), making it a reliable fallback.
+fn repo_has_root_skill_md(
+    repo: &str,
+    seen: &std::collections::HashSet<String>,
+) -> Vec<SearchResult> {
+    log::debug!("github: checking root SKILL.md in {repo} via contents API");
+    let endpoint = format!("repos/{repo}/contents/SKILL.md");
+    match ionem::shell::gh::api(endpoint).jq(".name").run() {
+        Ok(name) if name.trim().eq_ignore_ascii_case("SKILL.md") => {
+            if seen.contains(repo) {
+                return vec![];
+            }
+            let result =
+                SearchResult::new(repo.to_string(), String::new(), repo.to_string(), "github");
+            vec![result]
+        }
+        _ => vec![],
+    }
+}
+
 /// Check whether a repo has a SKILL.md at its root.
 fn repo_has_skill_md(repo: &str) -> bool {
     log::debug!("github: checking if {repo} has SKILL.md");
-    let Ok(body) = ionem::shell::gh::search_code("")
+    // Try code search first
+    if let Ok(body) = ionem::shell::gh::search_code("")
         .filename("SKILL.md")
         .repo(repo)
         .json(&["path", "repository"])
         .limit(1)
         .run()
-    else {
-        return false;
-    };
-    parse_gh_code_response(&body, 1).is_ok_and(|r| !r.is_empty())
+    {
+        return parse_gh_code_response(&body, 1).is_ok_and(|r| !r.is_empty());
+    }
+    // Fall back to Contents API if code search is rate-limited
+    log::debug!("github: falling back to contents API for {repo}");
+    let endpoint = format!("repos/{repo}/contents/SKILL.md");
+    ionem::shell::gh::api(endpoint)
+        .jq(".name")
+        .run()
+        .is_ok_and(|name| name.trim().eq_ignore_ascii_case("SKILL.md"))
 }
 
 /// Select up to `limit` results while ensuring repo diversity.

--- a/crates/ion-skill/src/search/github.rs
+++ b/crates/ion-skill/src/search/github.rs
@@ -386,21 +386,22 @@ fn select_with_diversity(
     results
 }
 
-/// Enrich GitHub search results by fetching SKILL.md descriptions from each repository.
-pub fn enrich_github_results(results: &mut [SearchResult]) {
+/// Enrich search results by fetching SKILL.md descriptions and star counts.
+/// Works for both GitHub and skills.sh results (skills.sh skills are GitHub-hosted).
+pub fn enrich_results(results: &mut [SearchResult]) {
     let handles: Vec<_> = results
         .iter()
         .enumerate()
-        .filter(|(_, r)| r.registry == "github" && !r.source.is_empty())
+        .filter(|(_, r)| !r.source.is_empty())
         .map(|(i, r)| {
             let source = r.source.clone();
-            let has_stars = r.stars.is_some();
+            let needs_stars = r.stars.is_none();
             std::thread::spawn(move || {
                 let desc = fetch_skill_description(&source);
-                let stars = if has_stars {
-                    None
-                } else {
+                let stars = if needs_stars {
                     fetch_stars(&source)
+                } else {
+                    None
                 };
                 (i, desc, stars)
             })
@@ -420,27 +421,41 @@ pub fn enrich_github_results(results: &mut [SearchResult]) {
 }
 
 /// Fetch the description from a SKILL.md file in a GitHub repository.
+/// Tries the direct path first, then common monorepo layouts (e.g. `skills/`).
 fn fetch_skill_description(source: &str) -> Option<String> {
     let repo = owner_repo_of(source);
     if repo.is_empty() || !repo.contains('/') {
         return None;
     }
 
-    let skill_path = source
+    let sub = source
         .strip_prefix(repo)
         .and_then(|s| s.strip_prefix('/'))
-        .map(|s| format!("{s}/SKILL.md"))
-        .unwrap_or_else(|| "SKILL.md".to_string());
+        .unwrap_or("");
 
-    log::debug!("enrich: fetching SKILL.md from {repo} path={skill_path}");
-    let stdout = ionem::shell::gh::api(format!("repos/{repo}/contents/{skill_path}"))
-        .jq(".content")
-        .run()
-        .ok()?;
+    // Build candidate paths: direct, then skills/ prefix, then root.
+    let mut candidates = Vec::with_capacity(3);
+    if !sub.is_empty() {
+        candidates.push(format!("{sub}/SKILL.md"));
+        candidates.push(format!("skills/{sub}/SKILL.md"));
+    }
+    candidates.push("SKILL.md".to_string());
 
-    let b64_clean: String = stdout.chars().filter(|c| !c.is_whitespace()).collect();
-    let decoded = base64_decode(&b64_clean)?;
-    parse_skill_description(&decoded)
+    for skill_path in &candidates {
+        log::debug!("enrich: trying SKILL.md from {repo} path={skill_path}");
+        if let Ok(stdout) = ionem::shell::gh::api(format!("repos/{repo}/contents/{skill_path}"))
+            .jq(".content")
+            .run()
+        {
+            let b64_clean: String = stdout.chars().filter(|c| !c.is_whitespace()).collect();
+            if let Some(decoded) = base64_decode(&b64_clean)
+                && let Some(desc) = parse_skill_description(&decoded)
+            {
+                return Some(desc);
+            }
+        }
+    }
+    None
 }
 
 /// Fetch star count for a repo.
@@ -564,7 +579,7 @@ mod tests {
         results.push(make_result("other/b", "other/b", 5));
         results.push(make_result("other/c", "other/c", 1));
 
-        SearchResult::sort_by_stars(&mut results);
+        SearchResult::sort_by_popularity(&mut results);
 
         let selected = select_with_diversity(results, 10, "skill");
         assert_eq!(selected.len(), 10);
@@ -594,7 +609,7 @@ mod tests {
         }
         results.push(make_result("small/a", "small/a", 500));
         results.push(make_result("small/b", "small/b", 200));
-        SearchResult::sort_by_stars(&mut results);
+        SearchResult::sort_by_popularity(&mut results);
 
         let selected = select_with_diversity(results, 10, "skill");
         // Results should still be sorted (by relevance now, not just stars)

--- a/crates/ion-skill/src/search/github.rs
+++ b/crates/ion-skill/src/search/github.rs
@@ -421,7 +421,7 @@ pub fn enrich_results(results: &mut [SearchResult]) {
 }
 
 /// Fetch the description from a SKILL.md file in a GitHub repository.
-/// Tries the direct path first, then common monorepo layouts (e.g. `skills/`).
+/// Tries common paths first, then falls back to searching the repo tree.
 fn fetch_skill_description(source: &str) -> Option<String> {
     let repo = owner_repo_of(source);
     if repo.is_empty() || !repo.contains('/') {
@@ -433,7 +433,7 @@ fn fetch_skill_description(source: &str) -> Option<String> {
         .and_then(|s| s.strip_prefix('/'))
         .unwrap_or("");
 
-    // Build candidate paths: direct, then skills/ prefix, then root.
+    // Try common paths first (cheap: one API call each).
     let mut candidates = Vec::with_capacity(3);
     if !sub.is_empty() {
         candidates.push(format!("{sub}/SKILL.md"));
@@ -443,19 +443,48 @@ fn fetch_skill_description(source: &str) -> Option<String> {
 
     for skill_path in &candidates {
         log::debug!("enrich: trying SKILL.md from {repo} path={skill_path}");
-        if let Ok(stdout) = ionem::shell::gh::api(format!("repos/{repo}/contents/{skill_path}"))
-            .jq(".content")
-            .run()
-        {
-            let b64_clean: String = stdout.chars().filter(|c| !c.is_whitespace()).collect();
-            if let Some(decoded) = base64_decode(&b64_clean)
-                && let Some(desc) = parse_skill_description(&decoded)
-            {
-                return Some(desc);
-            }
+        if let Some(desc) = fetch_skill_md_content(repo, skill_path) {
+            return Some(desc);
         }
     }
+
+    // Fallback: search the repo tree for a SKILL.md in a directory matching
+    // the skill name. This handles deeply nested monorepo layouts.
+    if !sub.is_empty() {
+        let suffix = format!("{sub}/SKILL.md");
+        log::debug!("enrich: searching repo tree for */{suffix} in {repo}");
+        if let Some(path) = find_skill_md_in_tree(repo, &suffix) {
+            return fetch_skill_md_content(repo, &path);
+        }
+    }
+
     None
+}
+
+/// Fetch and parse a SKILL.md at the given path, returning the description.
+fn fetch_skill_md_content(repo: &str, path: &str) -> Option<String> {
+    let stdout = ionem::shell::gh::api(format!("repos/{repo}/contents/{path}"))
+        .jq(".content")
+        .run()
+        .ok()?;
+    let b64_clean: String = stdout.chars().filter(|c| !c.is_whitespace()).collect();
+    let decoded = base64_decode(&b64_clean)?;
+    parse_skill_description(&decoded)
+}
+
+/// Search a repo's git tree for a SKILL.md path ending with `suffix`.
+fn find_skill_md_in_tree(repo: &str, suffix: &str) -> Option<String> {
+    let jq = format!("[.tree[].path | select(endswith(\"{suffix}\"))][0] // empty");
+    let path = ionem::shell::gh::api(format!("repos/{repo}/git/trees/HEAD?recursive=1"))
+        .jq(jq)
+        .run()
+        .ok()?;
+    let path = path.trim().trim_matches('"');
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
 }
 
 /// Fetch star count for a repo.

--- a/crates/ion-skill/src/search/mod.rs
+++ b/crates/ion-skill/src/search/mod.rs
@@ -6,9 +6,7 @@ mod skills_sh;
 
 pub use agent::{AgentSource, parse_agent_output};
 pub use cache::SearchCache;
-pub use github::{
-    GitHubSource, enrich_github_results, parse_gh_code_response, parse_gh_repo_response,
-};
+pub use github::{GitHubSource, enrich_results, parse_gh_code_response, parse_gh_repo_response};
 pub use registry::{RegistrySource, parse_registry_response};
 pub use skills_sh::{SkillsShSource, parse_skills_sh_page};
 
@@ -45,7 +43,10 @@ pub struct SearchResult {
     pub description: String,
     pub source: String,
     pub registry: String,
+    /// GitHub stargazer count.
     pub stars: Option<u64>,
+    /// skills.sh weekly install count.
+    pub weekly_installs: Option<u64>,
     pub skill_description: Option<String>,
 }
 
@@ -62,13 +63,20 @@ impl SearchResult {
             source: source.into(),
             registry: registry.into(),
             stars: None,
+            weekly_installs: None,
             skill_description: None,
         }
     }
 
-    /// Sort results by stars descending (missing stars treated as 0).
-    pub fn sort_by_stars(results: &mut [Self]) {
-        results.sort_by(|a, b| b.stars.unwrap_or(0).cmp(&a.stars.unwrap_or(0)));
+    /// The popularity value used for ranking: weekly installs for skills.sh,
+    /// stars for everything else.
+    pub fn popularity(&self) -> u64 {
+        self.weekly_installs.or(self.stars).unwrap_or(0)
+    }
+
+    /// Sort results by popularity descending.
+    pub fn sort_by_popularity(results: &mut [Self]) {
+        results.sort_by_key(|r| std::cmp::Reverse(r.popularity()));
     }
 
     /// Sort results by relevance to the query, combining text match quality
@@ -83,7 +91,7 @@ impl SearchResult {
         let mut max_by_registry: std::collections::HashMap<String, f64> =
             std::collections::HashMap::new();
         for r in results.iter() {
-            let val = r.stars.unwrap_or(0) as f64;
+            let val = r.popularity() as f64;
             let entry = max_by_registry.entry(r.registry.clone()).or_insert(0.0);
             if val > *entry {
                 *entry = val;
@@ -162,7 +170,7 @@ fn relevance_score(
 
     // Normalize popularity within each registry so different scales
     // (GitHub stars vs skills.sh weekly installs) are comparable.
-    let raw = result.stars.unwrap_or(0) as f64;
+    let raw = result.popularity() as f64;
     let max = max_by_registry
         .get(&result.registry)
         .copied()
@@ -385,11 +393,25 @@ pub(crate) fn parse_skill_description(content: &str) -> Option<String> {
     let rest = &content[3..];
     let end = rest.find("---")?;
     let frontmatter = &rest[..end];
-    for line in frontmatter.lines() {
-        let line = line.trim();
-        if let Some(value) = line.strip_prefix("description:") {
+    let lines: Vec<&str> = frontmatter.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
+        let trimmed = line.trim();
+        if let Some(value) = trimmed.strip_prefix("description:") {
             let value = value.trim().trim_matches('"').trim_matches('\'');
-            if !value.is_empty() {
+            // Handle YAML block scalars (> for folded, | for literal)
+            if value == ">" || value == "|" {
+                let mut parts = Vec::new();
+                for continuation in &lines[i + 1..] {
+                    if continuation.starts_with(' ') || continuation.starts_with('\t') {
+                        parts.push(continuation.trim());
+                    } else {
+                        break;
+                    }
+                }
+                if !parts.is_empty() {
+                    return Some(parts.join(" "));
+                }
+            } else if !value.is_empty() {
                 return Some(value.to_string());
             }
         }
@@ -561,6 +583,15 @@ mod tests {
     }
 
     #[test]
+    fn parse_skill_description_folded_scalar() {
+        let content = "---\nname: test\ndescription: >\n  Guide for writing idiomatic Rust code.\n  Use when reviewing Rust.\n---\n";
+        assert_eq!(
+            parse_skill_description(content),
+            Some("Guide for writing idiomatic Rust code. Use when reviewing Rust.".to_string())
+        );
+    }
+
+    #[test]
     fn parse_skill_description_missing() {
         let content = "---\nname: test\n---\n# No description";
         assert_eq!(parse_skill_description(content), None);
@@ -685,7 +716,7 @@ mod tests {
     }
 
     #[test]
-    fn sort_by_stars_descending() {
+    fn sort_by_popularity_descending() {
         let mut results = vec![
             {
                 let mut r = SearchResult::new("a", "", "", "test");
@@ -699,7 +730,7 @@ mod tests {
             },
             SearchResult::new("c", "", "", "test"),
         ];
-        SearchResult::sort_by_stars(&mut results);
+        SearchResult::sort_by_popularity(&mut results);
         assert_eq!(results[0].name, "b");
         assert_eq!(results[1].name, "a");
         assert_eq!(results[2].name, "c");

--- a/crates/ion-skill/src/search/mod.rs
+++ b/crates/ion-skill/src/search/mod.rs
@@ -72,15 +72,27 @@ impl SearchResult {
     }
 
     /// Sort results by relevance to the query, combining text match quality
-    /// with popularity (stars). Exact name/source matches rank highest,
-    /// then prefix matches, then substring matches, with stars as tiebreaker.
+    /// with normalized popularity. Popularity (stars / installs) is normalized
+    /// per-registry so that different scales (GitHub stars vs skills.sh weekly
+    /// installs) become comparable.
     pub fn sort_by_relevance(results: &mut [Self], query: &str) {
         let query_lower = query.to_lowercase();
         let query_words: Vec<&str> = query_lower.split_whitespace().collect();
 
+        // Compute max popularity per registry for normalization.
+        let mut max_by_registry: std::collections::HashMap<String, f64> =
+            std::collections::HashMap::new();
+        for r in results.iter() {
+            let val = r.stars.unwrap_or(0) as f64;
+            let entry = max_by_registry.entry(r.registry.clone()).or_insert(0.0);
+            if val > *entry {
+                *entry = val;
+            }
+        }
+
         results.sort_by(|a, b| {
-            let score_a = relevance_score(a, &query_lower, &query_words);
-            let score_b = relevance_score(b, &query_lower, &query_words);
+            let score_a = relevance_score(a, &query_lower, &query_words, &max_by_registry);
+            let score_b = relevance_score(b, &query_lower, &query_words, &max_by_registry);
             score_b
                 .partial_cmp(&score_a)
                 .unwrap_or(std::cmp::Ordering::Equal)
@@ -88,8 +100,15 @@ impl SearchResult {
     }
 }
 
+/// Maximum popularity bonus after normalization. This determines how much
+/// popularity matters relative to text relevance (max 1000). At 200, the
+/// most popular skill in any registry gets a meaningful boost but can't
+/// override a stronger text match (prefix > description + max popularity).
+const POPULARITY_WEIGHT: f64 = 200.0;
+
 /// Compute a relevance score for a search result against a query.
-/// Higher score = more relevant. Combines text match quality with popularity.
+/// Higher score = more relevant. Combines text match quality with
+/// popularity normalized across registries.
 ///
 /// Scoring:
 /// - Exact match on name/source segment:    1000
@@ -97,8 +116,14 @@ impl SearchResult {
 /// - All query words found in name/source:   200
 /// - Substring match in name/source:         100
 /// - Match in description:                    50
-/// - Popularity bonus: log2(stars + 1)     (0–20ish)
-fn relevance_score(result: &SearchResult, query: &str, query_words: &[&str]) -> f64 {
+/// - Normalized popularity:                 0–200
+///   (raw value / max in registry × POPULARITY_WEIGHT)
+fn relevance_score(
+    result: &SearchResult,
+    query: &str,
+    query_words: &[&str],
+    max_by_registry: &std::collections::HashMap<String, f64>,
+) -> f64 {
     let name_lower = result.name.to_lowercase();
     let source_lower = result.source.to_lowercase();
     let desc_lower = result.description.to_lowercase();
@@ -135,10 +160,17 @@ fn relevance_score(result: &SearchResult, query: &str, query_words: &[&str]) -> 
         text_score = 50.0;
     }
 
-    // Popularity bonus: logarithmic so stars don't dominate relevance
-    let star_bonus = (result.stars.unwrap_or(0) as f64 + 1.0).log2();
+    // Normalize popularity within each registry so different scales
+    // (GitHub stars vs skills.sh weekly installs) are comparable.
+    let raw = result.stars.unwrap_or(0) as f64;
+    let max = max_by_registry
+        .get(&result.registry)
+        .copied()
+        .unwrap_or(1.0)
+        .max(1.0);
+    let popularity_bonus = (raw / max) * POPULARITY_WEIGHT;
 
-    text_score + star_bonus
+    text_score + popularity_bonus
 }
 
 /// A searchable source of skills.

--- a/crates/ion-skill/src/search/skills_sh.rs
+++ b/crates/ion-skill/src/search/skills_sh.rs
@@ -108,7 +108,7 @@ pub fn parse_skills_sh_page(body: &str, query: &str, limit: usize) -> Vec<Search
             };
 
             let mut result = SearchResult::new(e.name, "", source, "skills.sh");
-            result.stars = Some(e.installs);
+            result.weekly_installs = Some(e.installs);
             result
         })
         .collect()
@@ -149,7 +149,7 @@ pub fn parse_skills_sh_api_response(body: &str, limit: usize) -> Vec<SearchResul
             };
 
             let mut result = SearchResult::new(e.name, "", source, "skills.sh");
-            result.stars = Some(e.installs);
+            result.weekly_installs = Some(e.installs);
             result
         })
         .collect()
@@ -207,7 +207,7 @@ mod tests {
         assert_eq!(results[0].name, "brainstorming");
         assert_eq!(results[0].source, "obra/superpowers/brainstorming");
         assert_eq!(results[0].registry, "skills.sh");
-        assert_eq!(results[0].stars, Some(5000));
+        assert_eq!(results[0].weekly_installs, Some(5000));
     }
 
     #[test]
@@ -250,7 +250,7 @@ mod tests {
             results[0].source,
             "apollographql/skills/rust-best-practices"
         );
-        assert_eq!(results[0].stars, Some(6219));
+        assert_eq!(results[0].weekly_installs, Some(6219));
         assert_eq!(results[0].registry, "skills.sh");
         assert_eq!(results[1].source, "wshobson/agents/rust-async-patterns");
     }

--- a/crates/ion-skill/src/search/skills_sh.rs
+++ b/crates/ion-skill/src/search/skills_sh.rs
@@ -114,7 +114,48 @@ pub fn parse_skills_sh_page(body: &str, query: &str, limit: usize) -> Vec<Search
         .collect()
 }
 
-/// Searches skills.sh by fetching the website and filtering the embedded skill catalog.
+/// JSON response from the skills.sh search API.
+#[derive(Deserialize)]
+struct SkillsShApiResponse {
+    #[serde(default)]
+    skills: Vec<SkillsShEntry>,
+}
+
+/// Parse the skills.sh search API JSON response.
+pub fn parse_skills_sh_api_response(body: &str, limit: usize) -> Vec<SearchResult> {
+    let resp: SkillsShApiResponse = match serde_json::from_str(body) {
+        Ok(r) => r,
+        Err(e) => {
+            log::debug!("skills.sh: failed to parse API response: {e}");
+            return vec![];
+        }
+    };
+
+    log::debug!("skills.sh: API returned {} skills", resp.skills.len());
+
+    resp.skills
+        .into_iter()
+        .take(limit)
+        .map(|e| {
+            let source = if e.source.contains('/') {
+                let repo_name = e.source.rsplit('/').next().unwrap_or("");
+                if e.skill_id != repo_name && !e.skill_id.is_empty() {
+                    format!("{}/{}", e.source, e.skill_id)
+                } else {
+                    e.source.clone()
+                }
+            } else {
+                e.source.clone()
+            };
+
+            let mut result = SearchResult::new(e.name, "", source, "skills.sh");
+            result.stars = Some(e.installs);
+            result
+        })
+        .collect()
+}
+
+/// Searches skills.sh using its search API, falling back to homepage scraping.
 pub struct SkillsShSource;
 
 impl SearchSource for SkillsShSource {
@@ -123,6 +164,28 @@ impl SearchSource for SkillsShSource {
     }
 
     fn search(&self, query: &str, limit: usize) -> crate::Result<Vec<SearchResult>> {
+        // Try the search API first
+        log::debug!("skills.sh: querying search API for {query:?}");
+        match super::http_get_with_query(
+            "https://skills.sh/api/search",
+            &[("q", query)],
+            15,
+            "skills.sh",
+        ) {
+            Ok(body) => {
+                let results = parse_skills_sh_api_response(&body, limit);
+                if !results.is_empty() {
+                    log::debug!("skills.sh: API returned {} results", results.len());
+                    return Ok(results);
+                }
+                log::debug!("skills.sh: API returned 0 results, falling back to page scrape");
+            }
+            Err(e) => {
+                log::debug!("skills.sh: API failed ({e}), falling back to page scrape");
+            }
+        }
+
+        // Fallback: scrape the homepage
         log::debug!("skills.sh: fetching website");
         let body = super::http_get("https://skills.sh/", 15, "skills.sh")?;
         log::debug!("skills.sh: received {} bytes", body.len());
@@ -175,5 +238,27 @@ mod tests {
         let results = parse_skills_sh_page(body, "tdd", 10);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].source, "acme/tdd");
+    }
+
+    #[test]
+    fn skills_sh_api_response_parses() {
+        let body = r#"{"query":"rust","searchType":"fuzzy","skills":[{"source":"apollographql/skills","skillId":"rust-best-practices","name":"rust-best-practices","installs":6219},{"source":"wshobson/agents","skillId":"rust-async-patterns","name":"rust-async-patterns","installs":7967}],"count":2,"duration_ms":10}"#;
+        let results = parse_skills_sh_api_response(body, 10);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "rust-best-practices");
+        assert_eq!(
+            results[0].source,
+            "apollographql/skills/rust-best-practices"
+        );
+        assert_eq!(results[0].stars, Some(6219));
+        assert_eq!(results[0].registry, "skills.sh");
+        assert_eq!(results[1].source, "wshobson/agents/rust-async-patterns");
+    }
+
+    #[test]
+    fn skills_sh_api_response_respects_limit() {
+        let body = r#"{"skills":[{"source":"a/b","skillId":"s1","name":"s1","installs":100},{"source":"a/b","skillId":"s2","name":"s2","installs":50}]}"#;
+        let results = parse_skills_sh_api_response(body, 1);
+        assert_eq!(results.len(), 1);
     }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -264,6 +264,19 @@ fn group_by_owner_repo_refs<'a>(
     groups
 }
 
+/// Build a web URL for the result's source.
+fn source_url(registry: &str, source: &str) -> String {
+    match registry {
+        "skills.sh" | "skills-sh" => format!("https://skills.sh/{source}"),
+        _ => format!("https://github.com/{source}"),
+    }
+}
+
+/// Wrap `text` in an OSC 8 terminal hyperlink pointing to `url`.
+fn terminal_link(text: &str, url: &str) -> String {
+    format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\")
+}
+
 /// Format the metrics line for a search result (stars and/or weekly installs).
 fn format_metrics(r: &SearchResult) -> String {
     let mut parts = Vec::new();
@@ -296,14 +309,16 @@ fn print_single_result(r: &SearchResult, rank: usize, color: bool) {
     }
 
     let metrics = format_metrics(r);
+    let url = source_url(&r.registry, &r.source);
+    let linked_name = terminal_link(&r.name, &url);
     if color {
         print!(
             "  {rank}. {}{}",
-            r.name.clone().white().bold(),
+            linked_name.clone().white().bold(),
             metrics.clone().grey()
         );
     } else {
-        print!("  {rank}. {}{}", r.name, metrics);
+        print!("  {rank}. {}{}", linked_name, metrics);
     }
     println!();
 
@@ -322,9 +337,11 @@ fn print_repo_group(owner_repo: &str, group: &[&SearchResult], rank: usize, colo
     let width = terminal_width();
 
     let metrics = format_metrics(r0);
+    let url = source_url(&r0.registry, owner_repo);
+    let linked_repo = terminal_link(owner_repo, &url);
     let heading = format!(
         "{rank}. {}{}  ({} skill{})",
-        owner_repo,
+        linked_repo,
         metrics,
         skill_count,
         if skill_count == 1 { "" } else { "s" }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -4,7 +4,7 @@ use crossterm::style::Stylize;
 use ion_skill::config::GlobalConfig;
 use ion_skill::search::{
     AgentSource, GitHubSource, RegistrySource, SearchCache, SearchResult, SearchSource,
-    SkillsShSource, enrich_github_results, owner_repo_of, parallel_search, skill_dir_name,
+    SkillsShSource, enrich_results, owner_repo_of, parallel_search, skill_dir_name,
 };
 
 pub fn run(
@@ -39,7 +39,7 @@ pub fn run(
         "found {} total results, enriching GitHub results",
         results.len()
     );
-    enrich_github_results(&mut results);
+    enrich_results(&mut results);
 
     if json {
         crate::json::print_success(&results);
@@ -212,6 +212,7 @@ fn print_results(results: &[SearchResult]) {
         }
     }
 
+    let mut rank = 1usize;
     for (i, registry) in registries.iter().enumerate() {
         if i > 0 {
             println!();
@@ -235,10 +236,11 @@ fn print_results(results: &[SearchResult]) {
             }
 
             if group.len() == 1 {
-                print_single_result(group[0], color);
+                print_single_result(group[0], rank, color);
             } else {
-                print_repo_group(owner_repo, group, color);
+                print_repo_group(owner_repo, group, rank, color);
             }
+            rank += 1;
         }
     }
 }
@@ -262,10 +264,19 @@ fn group_by_owner_repo_refs<'a>(
     groups
 }
 
-fn format_stars(stars: Option<u64>) -> String {
-    match stars {
-        Some(n) => format!("  * {n}"),
-        None => String::new(),
+/// Format the metrics line for a search result (stars and/or weekly installs).
+fn format_metrics(r: &SearchResult) -> String {
+    let mut parts = Vec::new();
+    if let Some(s) = r.stars {
+        parts.push(format!("{s} stars"));
+    }
+    if let Some(w) = r.weekly_installs {
+        parts.push(format!("{w} installs/wk"));
+    }
+    if parts.is_empty() {
+        String::new()
+    } else {
+        format!("  ({})", parts.join(", "))
     }
 }
 
@@ -278,21 +289,21 @@ fn print_install_line(source: &str, color: bool) {
     }
 }
 
-fn print_single_result(r: &SearchResult, color: bool) {
+fn print_single_result(r: &SearchResult, rank: usize, color: bool) {
     if r.source.is_empty() {
         println!("  {}", r.description);
         return;
     }
 
-    let stars = format_stars(r.stars);
+    let metrics = format_metrics(r);
     if color {
         print!(
-            "  {}{}",
+            "  {rank}. {}{}",
             r.name.clone().white().bold(),
-            stars.white().bold()
+            metrics.clone().grey()
         );
     } else {
-        print!("  {}{}", r.name, stars);
+        print!("  {rank}. {}{}", r.name, metrics);
     }
     println!();
 
@@ -305,16 +316,16 @@ fn print_single_result(r: &SearchResult, color: bool) {
     print_install_line(&r.source, color);
 }
 
-fn print_repo_group(owner_repo: &str, group: &[&SearchResult], color: bool) {
+fn print_repo_group(owner_repo: &str, group: &[&SearchResult], rank: usize, color: bool) {
     let r0 = group[0];
     let skill_count = group.len();
     let width = terminal_width();
 
-    let stars = format_stars(r0.stars);
+    let metrics = format_metrics(r0);
     let heading = format!(
-        "{}{}  ({} skill{})",
+        "{rank}. {}{}  ({} skill{})",
         owner_repo,
-        stars,
+        metrics,
         skill_count,
         if skill_count == 1 { "" } else { "s" }
     );
@@ -324,9 +335,17 @@ fn print_repo_group(owner_repo: &str, group: &[&SearchResult], color: bool) {
         println!("  {heading}");
     }
 
-    if !r0.description.is_empty() {
+    // Show first available description from the group
+    let desc = group
+        .iter()
+        .find_map(|r| r.skill_description.as_deref())
+        .or_else(|| {
+            let d = r0.description.as_str();
+            if d.is_empty() { None } else { Some(d) }
+        });
+    if let Some(desc) = desc {
         let usable = width.saturating_sub(4).max(20);
-        print_wrapped(&r0.description, 4, usable, 2, color);
+        print_wrapped(desc, 4, usable, 2, color);
     }
 
     let skill_names: Vec<&str> = group.iter().map(|r| skill_dir_name(&r.source)).collect();

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -293,12 +293,23 @@ fn format_metrics(r: &SearchResult) -> String {
     }
 }
 
-fn print_install_line(source: &str, color: bool) {
+/// Short display label for a registry link.
+fn registry_link_label(registry: &str) -> &str {
+    match registry {
+        "skills.sh" | "skills-sh" => "skills.sh",
+        _ => "github.com",
+    }
+}
+
+fn print_install_line(source: &str, registry: &str, color: bool) {
+    let url = source_url(registry, source);
+    let label = registry_link_label(registry);
+    let link = terminal_link(label, &url);
     let line = format!("ion add {source}");
     if color {
-        println!("    {}", line.grey());
+        println!("    {}  {}", line.grey(), link.dark_blue());
     } else {
-        println!("    {line}");
+        println!("    {line}  {link}");
     }
 }
 
@@ -309,16 +320,14 @@ fn print_single_result(r: &SearchResult, rank: usize, color: bool) {
     }
 
     let metrics = format_metrics(r);
-    let url = source_url(&r.registry, &r.source);
-    let linked_name = terminal_link(&r.name, &url);
     if color {
         print!(
             "  {rank}. {}{}",
-            linked_name.clone().white().bold(),
+            r.name.clone().white().bold(),
             metrics.clone().grey()
         );
     } else {
-        print!("  {rank}. {}{}", linked_name, metrics);
+        print!("  {rank}. {}{}", r.name, metrics);
     }
     println!();
 
@@ -328,7 +337,7 @@ fn print_single_result(r: &SearchResult, rank: usize, color: bool) {
         print_wrapped(desc, 4, usable, 2, color);
     }
 
-    print_install_line(&r.source, color);
+    print_install_line(&r.source, &r.registry, color);
 }
 
 fn print_repo_group(owner_repo: &str, group: &[&SearchResult], rank: usize, color: bool) {
@@ -337,11 +346,9 @@ fn print_repo_group(owner_repo: &str, group: &[&SearchResult], rank: usize, colo
     let width = terminal_width();
 
     let metrics = format_metrics(r0);
-    let url = source_url(&r0.registry, owner_repo);
-    let linked_repo = terminal_link(owner_repo, &url);
     let heading = format!(
         "{rank}. {}{}  ({} skill{})",
-        linked_repo,
+        owner_repo,
         metrics,
         skill_count,
         if skill_count == 1 { "" } else { "s" }
@@ -373,7 +380,7 @@ fn print_repo_group(owner_repo: &str, group: &[&SearchResult], rank: usize, colo
         println!("    {skills_line}");
     }
 
-    print_install_line(owner_repo, color);
+    print_install_line(owner_repo, &r0.registry, color);
 }
 
 /// Join names with ", " and truncate with "..." if it exceeds `max_width`.

--- a/src/tui/search_app.rs
+++ b/src/tui/search_app.rs
@@ -8,6 +8,7 @@ pub enum ListRow {
     RepoHeader {
         owner_repo: String,
         stars: Option<u64>,
+        weekly_installs: Option<u64>,
         description: String,
         skill_count: usize,
         registry: String,
@@ -30,7 +31,7 @@ impl SearchApp {
     pub fn new(mut results: Vec<SearchResult>) -> Self {
         // Results arrive pre-sorted by unified relevance scoring (text match +
         // normalized popularity). Re-sort by stars as a simple TUI ordering.
-        SearchResult::sort_by_stars(&mut results);
+        SearchResult::sort_by_popularity(&mut results);
         let rows = build_rows(&results);
         Self {
             results,
@@ -87,6 +88,7 @@ fn build_rows(results: &[SearchResult]) -> Vec<ListRow> {
             rows.push(ListRow::RepoHeader {
                 owner_repo,
                 stars: first.stars,
+                weekly_installs: first.weekly_installs,
                 description: first.description.clone(),
                 skill_count: indices.len(),
                 registry: first.registry.clone(),

--- a/src/tui/search_app.rs
+++ b/src/tui/search_app.rs
@@ -28,6 +28,8 @@ pub struct SearchApp {
 
 impl SearchApp {
     pub fn new(mut results: Vec<SearchResult>) -> Self {
+        // Results arrive pre-sorted by unified relevance scoring (text match +
+        // normalized popularity). Re-sort by stars as a simple TUI ordering.
         SearchResult::sort_by_stars(&mut results);
         let rows = build_rows(&results);
         Self {

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -201,7 +201,7 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
     lines.push(Line::from(""));
 
     let url = source_url(&r.registry, &r.source);
-    push_styled_section(&mut lines, "Link:", &url, wrap_width, LINK_STYLE);
+    push_link_section(&mut lines, &url, wrap_width);
 
     // Show skill description first (from SKILL.md), then repo description
     if let Some(ref skill_desc) = r.skill_description {
@@ -266,7 +266,7 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
     ]));
 
     let url = source_url(registry, owner_repo);
-    push_styled_section(&mut lines, "Link:", &url, wrap_width, LINK_STYLE);
+    push_link_section(&mut lines, &url, wrap_width);
 
     push_wrapped_section(&mut lines, "Description:", description, wrap_width);
 
@@ -304,6 +304,22 @@ fn push_styled_section<'a>(
     lines.push(Line::from(Span::styled(label, LABEL_STYLE)));
     for wrapped_line in wrap_text(text, wrap_width) {
         lines.push(Line::from(Span::styled(format!("  {wrapped_line}"), style)));
+    }
+    lines.push(Line::from(""));
+}
+
+/// Append a link section with character-level wrapping (URLs have no spaces).
+fn push_link_section(lines: &mut Vec<Line<'_>>, url: &str, wrap_width: usize) {
+    if url.is_empty() {
+        return;
+    }
+    lines.push(Line::from(Span::styled("Link:", LABEL_STYLE)));
+    let indent = 2;
+    let usable = wrap_width.saturating_sub(indent);
+    for chunk in url.as_bytes().chunks(usable.max(1)) {
+        let s = std::str::from_utf8(chunk).unwrap_or("");
+        let pad = " ".repeat(indent);
+        lines.push(Line::from(Span::styled(format!("{pad}{s}"), LINK_STYLE)));
     }
     lines.push(Line::from(""));
 }

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -24,11 +24,6 @@ fn source_url(registry: &str, source: &str) -> String {
     }
 }
 
-/// Wrap `text` in an OSC 8 terminal hyperlink.
-fn format_terminal_link(text: &str, url: &str) -> String {
-    format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\")
-}
-
 pub fn render_search(frame: &mut Frame, app: &mut SearchApp) {
     let area = frame.area();
 
@@ -207,7 +202,7 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
     let url = source_url(&r.registry, &r.source);
     lines.push(Line::from(vec![
         Span::styled("Link:    ", LABEL_STYLE),
-        Span::styled(format_terminal_link(&url, &url), LINK_STYLE),
+        Span::styled(url, LINK_STYLE),
     ]));
     lines.push(Line::from(""));
 
@@ -276,7 +271,7 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
     let url = source_url(registry, owner_repo);
     lines.push(Line::from(vec![
         Span::styled("Link:    ", LABEL_STYLE),
-        Span::styled(format_terminal_link(&url, &url), LINK_STYLE),
+        Span::styled(url, LINK_STYLE),
     ]));
     lines.push(Line::from(""));
 

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -11,7 +11,23 @@ use super::util::wrap_text;
 
 const LABEL_STYLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
 const VALUE_STYLE: Style = Style::new().fg(Color::White);
+const LINK_STYLE: Style = Style::new()
+    .fg(Color::Blue)
+    .add_modifier(Modifier::UNDERLINED);
 const DIM_STYLE: Style = Style::new().fg(Color::DarkGray);
+
+/// Build a web URL for a result source.
+fn source_url(registry: &str, source: &str) -> String {
+    match registry {
+        "skills.sh" | "skills-sh" => format!("https://skills.sh/{source}"),
+        _ => format!("https://github.com/{source}"),
+    }
+}
+
+/// Wrap `text` in an OSC 8 terminal hyperlink.
+fn format_terminal_link(text: &str, url: &str) -> String {
+    format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\")
+}
 
 pub fn render_search(frame: &mut Frame, app: &mut SearchApp) {
     let area = frame.area();
@@ -187,6 +203,12 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
     ];
 
     push_metric_lines(&mut lines, r.stars, r.weekly_installs);
+
+    let url = source_url(&r.registry, &r.source);
+    lines.push(Line::from(vec![
+        Span::styled("Link:    ", LABEL_STYLE),
+        Span::styled(format_terminal_link(&url, &url), LINK_STYLE),
+    ]));
     lines.push(Line::from(""));
 
     // Show skill description first (from SKILL.md), then repo description
@@ -249,6 +271,12 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
     lines.push(Line::from(vec![
         Span::styled("Skills:  ", LABEL_STYLE),
         Span::styled(skill_count.to_string(), VALUE_STYLE),
+    ]));
+
+    let url = source_url(registry, owner_repo);
+    lines.push(Line::from(vec![
+        Span::styled("Link:    ", LABEL_STYLE),
+        Span::styled(format_terminal_link(&url, &url), LINK_STYLE),
     ]));
     lines.push(Line::from(""));
 

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -198,13 +198,10 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
     ];
 
     push_metric_lines(&mut lines, r.stars, r.weekly_installs);
+    lines.push(Line::from(""));
 
     let url = source_url(&r.registry, &r.source);
-    lines.push(Line::from(vec![
-        Span::styled("Link:    ", LABEL_STYLE),
-        Span::styled(url, LINK_STYLE),
-    ]));
-    lines.push(Line::from(""));
+    push_styled_section(&mut lines, "Link:", &url, wrap_width, LINK_STYLE);
 
     // Show skill description first (from SKILL.md), then repo description
     if let Some(ref skill_desc) = r.skill_description {
@@ -269,11 +266,7 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
     ]));
 
     let url = source_url(registry, owner_repo);
-    lines.push(Line::from(vec![
-        Span::styled("Link:    ", LABEL_STYLE),
-        Span::styled(url, LINK_STYLE),
-    ]));
-    lines.push(Line::from(""));
+    push_styled_section(&mut lines, "Link:", &url, wrap_width, LINK_STYLE);
 
     push_wrapped_section(&mut lines, "Description:", description, wrap_width);
 
@@ -294,15 +287,23 @@ fn push_wrapped_section<'a>(
     text: &str,
     wrap_width: usize,
 ) {
+    push_styled_section(lines, label, text, wrap_width, VALUE_STYLE);
+}
+
+/// Append a labeled wrapped section with a custom style.
+fn push_styled_section<'a>(
+    lines: &mut Vec<Line<'a>>,
+    label: &'a str,
+    text: &str,
+    wrap_width: usize,
+    style: Style,
+) {
     if text.is_empty() {
         return;
     }
     lines.push(Line::from(Span::styled(label, LABEL_STYLE)));
     for wrapped_line in wrap_text(text, wrap_width) {
-        lines.push(Line::from(Span::styled(
-            format!("  {wrapped_line}"),
-            VALUE_STYLE,
-        )));
+        lines.push(Line::from(Span::styled(format!("  {wrapped_line}"), style)));
     }
     lines.push(Line::from(""));
 }

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -56,6 +56,7 @@ fn render_list(frame: &mut Frame, app: &SearchApp, area: Rect) {
             ListRow::RepoHeader {
                 owner_repo,
                 stars,
+                weekly_installs,
                 skill_count,
                 ..
             } => {
@@ -69,7 +70,7 @@ fn render_list(frame: &mut Frame, app: &SearchApp, area: Rect) {
                         .fg(Color::Cyan)
                         .add_modifier(Modifier::BOLD)
                 };
-                let stars_str = format_stars_compact(*stars);
+                let stars_str = format_metric_compact_raw(*stars, *weekly_installs);
                 lines.push(Line::from(vec![
                     Span::styled(prefix, style),
                     Span::styled(owner_repo.as_str(), style),
@@ -117,7 +118,7 @@ fn render_list(frame: &mut Frame, app: &SearchApp, area: Rect) {
                 let stars_str = if *grouped {
                     String::new()
                 } else {
-                    format_stars_compact(r.stars)
+                    format_metric_compact(r)
                 };
 
                 let badge = if *grouped {
@@ -156,21 +157,7 @@ fn render_detail(frame: &mut Frame, app: &SearchApp, area: Rect) {
 
     match row {
         ListRow::Skill { result_idx, .. } => render_skill_detail(frame, app, inner, *result_idx),
-        ListRow::RepoHeader {
-            owner_repo,
-            stars,
-            description,
-            skill_count,
-            registry,
-        } => render_repo_detail(
-            frame,
-            inner,
-            owner_repo,
-            *stars,
-            description,
-            *skill_count,
-            registry,
-        ),
+        ListRow::RepoHeader { .. } => render_repo_detail(frame, inner, row),
     }
 }
 
@@ -183,7 +170,6 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
         .source
         .split_once('/')
         .map_or(r.source.as_str(), |(owner, _)| owner);
-    let stars_str = r.stars.map_or("—".to_string(), |n| n.to_string());
     let wrap_width = area.width.saturating_sub(2) as usize;
 
     let mut lines: Vec<Line> = vec![
@@ -195,20 +181,19 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
             ),
         ]),
         Line::from(vec![
-            Span::styled("Owner: ", LABEL_STYLE),
+            Span::styled("Owner:  ", LABEL_STYLE),
             Span::styled(owner, VALUE_STYLE),
         ]),
-        Line::from(vec![
-            Span::styled("Stars: ", LABEL_STYLE),
-            Span::styled(format!("* {stars_str}"), VALUE_STYLE),
-        ]),
-        Line::from(""),
     ];
 
-    push_wrapped_section(&mut lines, "Description:", &r.description, wrap_width);
+    push_metric_lines(&mut lines, r.stars, r.weekly_installs);
+    lines.push(Line::from(""));
 
+    // Show skill description first (from SKILL.md), then repo description
     if let Some(ref skill_desc) = r.skill_description {
-        push_wrapped_section(&mut lines, "Skill Description:", skill_desc, wrap_width);
+        push_wrapped_section(&mut lines, "Description:", skill_desc, wrap_width);
+    } else if !r.description.is_empty() {
+        push_wrapped_section(&mut lines, "Description:", &r.description, wrap_width);
     }
 
     if !r.source.is_empty() {
@@ -223,47 +208,49 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
     frame.render_widget(paragraph, area);
 }
 
-fn render_repo_detail(
-    frame: &mut Frame,
-    area: Rect,
-    owner_repo: &str,
-    stars: Option<u64>,
-    description: &str,
-    skill_count: usize,
-    registry: &str,
-) {
+fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
+    let ListRow::RepoHeader {
+        owner_repo,
+        stars,
+        weekly_installs,
+        description,
+        skill_count,
+        registry,
+    } = row
+    else {
+        return;
+    };
+
     let owner = owner_repo
         .split_once('/')
-        .map_or(owner_repo, |(owner, _)| owner);
-    let stars_str = stars.map_or("—".to_string(), |n| n.to_string());
+        .map_or(owner_repo.as_str(), |(o, _)| o);
     let wrap_width = area.width.saturating_sub(2) as usize;
 
     let mut lines: Vec<Line> = vec![
         Line::from(vec![
-            Span::styled("Source: ", LABEL_STYLE),
+            Span::styled("Source:  ", LABEL_STYLE),
             Span::styled(
                 registry_label(registry),
                 Style::new().fg(registry_color(registry)),
             ),
         ]),
         Line::from(vec![
-            Span::styled("Repo: ", LABEL_STYLE),
-            Span::styled(owner_repo, VALUE_STYLE),
+            Span::styled("Repo:    ", LABEL_STYLE),
+            Span::styled(owner_repo.as_str(), VALUE_STYLE),
         ]),
         Line::from(vec![
-            Span::styled("Owner: ", LABEL_STYLE),
+            Span::styled("Owner:   ", LABEL_STYLE),
             Span::styled(owner, VALUE_STYLE),
         ]),
-        Line::from(vec![
-            Span::styled("Stars: ", LABEL_STYLE),
-            Span::styled(format!("* {stars_str}"), VALUE_STYLE),
-        ]),
-        Line::from(vec![
-            Span::styled("Skills: ", LABEL_STYLE),
-            Span::styled(skill_count.to_string(), VALUE_STYLE),
-        ]),
-        Line::from(""),
     ];
+
+    push_metric_lines(&mut lines, *stars, *weekly_installs);
+
+    lines.push(Line::from(vec![
+        Span::styled("Skills:  ", LABEL_STYLE),
+        Span::styled(skill_count.to_string(), VALUE_STYLE),
+    ]));
+    lines.push(Line::from(""));
 
     push_wrapped_section(&mut lines, "Description:", description, wrap_width);
 
@@ -297,10 +284,45 @@ fn push_wrapped_section<'a>(
     lines.push(Line::from(""));
 }
 
-fn format_stars_compact(stars: Option<u64>) -> String {
-    match stars {
-        Some(n) => format!(" *{n}"),
-        None => String::new(),
+/// Format a compact metric badge for the list view.
+fn format_metric_compact(r: &ion_skill::search::SearchResult) -> String {
+    if let Some(w) = r.weekly_installs {
+        format!(" {w}/wk")
+    } else if let Some(s) = r.stars {
+        format!(" *{s}")
+    } else {
+        String::new()
+    }
+}
+
+/// Format a compact metric badge for repo headers.
+fn format_metric_compact_raw(stars: Option<u64>, weekly_installs: Option<u64>) -> String {
+    if let Some(w) = weekly_installs {
+        format!(" {w}/wk")
+    } else if let Some(s) = stars {
+        format!(" *{s}")
+    } else {
+        String::new()
+    }
+}
+
+/// Push metric lines (stars and/or weekly installs) into the detail panel.
+fn push_metric_lines<'a>(
+    lines: &mut Vec<Line<'a>>,
+    stars: Option<u64>,
+    weekly_installs: Option<u64>,
+) {
+    if let Some(s) = stars {
+        lines.push(Line::from(vec![
+            Span::styled("Stars:   ", LABEL_STYLE),
+            Span::styled(s.to_string(), VALUE_STYLE),
+        ]));
+    }
+    if let Some(w) = weekly_installs {
+        lines.push(Line::from(vec![
+            Span::styled("Installs:", LABEL_STYLE),
+            Span::styled(format!(" {w}/wk"), VALUE_STYLE),
+        ]));
     }
 }
 


### PR DESCRIPTION
## Summary

- **skills.sh search API**: Use `/api/search` endpoint instead of scraping the homepage's embedded `initialSkills` catalog. Returns ~100 results vs the previous ~1 for broad queries like "rust". Falls back to homepage scraping if the API is unavailable.
- **Unified popularity scoring**: Normalize popularity per-registry (raw value / max in group × 200) so GitHub stars and skills.sh weekly installs are on the same scale. Removes the hard registry priority separation — results are now ranked by text relevance + normalized popularity across all sources.
- **Skill-focused GitHub repo search**: Adds a supplementary `"{query} skill"` repo search pass to surface skill repos that would otherwise be drowned out by popular non-skill repos (e.g. `rust-lang/rust` drowning `leonardomso/rust-skills`).
- **Contents API fallback**: When GitHub code search hits its rate limit (30 req/min), falls back to the Contents API (5000 req/hr) to check for SKILL.md, preventing repos from being silently dropped.

## Test plan
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo nextest run` — 305 tests pass
- [x] `cargo test -p ion-skill --lib` — all unit tests pass including new `skills_sh_api_response_parses` and `skills_sh_api_response_respects_limit`
- [x] Manual: `ion search rust` returns skills.sh results (including `apollographql/skills/rust-best-practices`) and `leonardomso/rust-skills` from GitHub
- [ ] Manual: verify TUI picker ordering with `ion search rust` in a terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)