### PR TITLE
fix: improve search link display with clickable OSC 8 hyperlinks

### DIFF
--- a/crates/ion-skill/src/search/skills_sh.rs
+++ b/crates/ion-skill/src/search/skills_sh.rs
@@ -96,18 +96,20 @@ pub fn parse_skills_sh_page(body: &str, query: &str, limit: usize) -> Vec<Search
         })
         .take(limit)
         .map(|e| {
-            let source = if e.source.contains('/') {
-                let repo_name = e.source.rsplit('/').next().unwrap_or("");
-                if e.skill_id != repo_name && !e.skill_id.is_empty() {
-                    format!("{}/{}", e.source, e.skill_id)
+            let src = e.source.trim();
+            let sid = e.skill_id.trim();
+            let source = if src.contains('/') {
+                let repo_name = src.rsplit('/').next().unwrap_or("");
+                if sid != repo_name && !sid.is_empty() {
+                    format!("{src}/{sid}")
                 } else {
-                    e.source.clone()
+                    src.to_string()
                 }
             } else {
-                e.source.clone()
+                src.to_string()
             };
 
-            let mut result = SearchResult::new(e.name, "", source, "skills.sh");
+            let mut result = SearchResult::new(e.name.trim(), "", source, "skills.sh");
             result.weekly_installs = Some(e.installs);
             result
         })
@@ -137,18 +139,20 @@ pub fn parse_skills_sh_api_response(body: &str, limit: usize) -> Vec<SearchResul
         .into_iter()
         .take(limit)
         .map(|e| {
-            let source = if e.source.contains('/') {
-                let repo_name = e.source.rsplit('/').next().unwrap_or("");
-                if e.skill_id != repo_name && !e.skill_id.is_empty() {
-                    format!("{}/{}", e.source, e.skill_id)
+            let src = e.source.trim();
+            let sid = e.skill_id.trim();
+            let source = if src.contains('/') {
+                let repo_name = src.rsplit('/').next().unwrap_or("");
+                if sid != repo_name && !sid.is_empty() {
+                    format!("{src}/{sid}")
                 } else {
-                    e.source.clone()
+                    src.to_string()
                 }
             } else {
-                e.source.clone()
+                src.to_string()
             };
 
-            let mut result = SearchResult::new(e.name, "", source, "skills.sh");
+            let mut result = SearchResult::new(e.name.trim(), "", source, "skills.sh");
             result.weekly_installs = Some(e.installs);
             result
         })
@@ -260,5 +264,23 @@ mod tests {
         let body = r#"{"skills":[{"source":"a/b","skillId":"s1","name":"s1","installs":100},{"source":"a/b","skillId":"s2","name":"s2","installs":50}]}"#;
         let results = parse_skills_sh_api_response(body, 1);
         assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn skills_sh_api_trims_whitespace() {
+        let body = r#"{"skills":[{"source":" wshobson/agents ","skillId":" rust-async-patterns ","name":" rust-async-patterns ","installs":100}]}"#;
+        let results = parse_skills_sh_api_response(body, 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "rust-async-patterns");
+        assert_eq!(results[0].source, "wshobson/agents/rust-async-patterns");
+    }
+
+    #[test]
+    fn skills_sh_page_trims_whitespace() {
+        let body = r#"x"initialSkills":[{"source":" owner/repo ","skillId":" my-skill ","name":" my-skill ","installs":42}]y"#;
+        let results = parse_skills_sh_page(body, "my-skill", 10);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "my-skill");
+        assert_eq!(results[0].source, "owner/repo/my-skill");
     }
 }

--- a/src/commands/search.rs
+++ b/src/commands/search.rs
@@ -272,11 +272,6 @@ fn source_url(registry: &str, source: &str) -> String {
     }
 }
 
-/// Wrap `text` in an OSC 8 terminal hyperlink pointing to `url`.
-fn terminal_link(text: &str, url: &str) -> String {
-    format!("\x1b]8;;{url}\x1b\\{text}\x1b]8;;\x1b\\")
-}
-
 /// Format the metrics line for a search result (stars and/or weekly installs).
 fn format_metrics(r: &SearchResult) -> String {
     let mut parts = Vec::new();
@@ -293,23 +288,13 @@ fn format_metrics(r: &SearchResult) -> String {
     }
 }
 
-/// Short display label for a registry link.
-fn registry_link_label(registry: &str) -> &str {
-    match registry {
-        "skills.sh" | "skills-sh" => "skills.sh",
-        _ => "github.com",
-    }
-}
-
 fn print_install_line(source: &str, registry: &str, color: bool) {
     let url = source_url(registry, source);
-    let label = registry_link_label(registry);
-    let link = terminal_link(label, &url);
     let line = format!("ion add {source}");
     if color {
-        println!("    {}  {}", line.grey(), link.dark_blue());
+        println!("    {}  {}", line.grey(), url.dark_blue());
     } else {
-        println!("    {line}  {link}");
+        println!("    {line}  {url}");
     }
 }
 
@@ -432,7 +417,12 @@ fn print_wrapped(text: &str, indent: usize, width: usize, max_lines: usize, colo
 }
 
 fn pick_and_install(results: &[SearchResult]) -> anyhow::Result<()> {
+    use std::io::Write;
+
+    use crossterm::cursor::MoveTo;
     use crossterm::event::{self, Event};
+    use crossterm::queue;
+    use crossterm::style::{Print, SetAttribute, SetForegroundColor};
 
     use crate::tui::search_app::SearchApp;
     use crate::tui::search_event::handle_search_key;
@@ -454,6 +444,26 @@ fn pick_and_install(results: &[SearchResult]) -> anyhow::Result<()> {
     run_tui(|terminal| {
         loop {
             terminal.draw(|frame| render_search(frame, &mut app))?;
+
+            // Emit OSC 8 hyperlinks after draw — ratatui doesn't support
+            // hyperlinks natively, so we re-print the link text wrapped in
+            // OSC 8 sequences at the known positions.
+            {
+                let writer = terminal.backend_mut();
+                for link in &app.hyperlinks {
+                    queue!(
+                        writer,
+                        MoveTo(link.x, link.y),
+                        Print(format!("\x1b]8;;{}\x07", link.url)),
+                        SetForegroundColor(crossterm::style::Color::Blue),
+                        SetAttribute(crossterm::style::Attribute::Underlined),
+                        Print(&link.text),
+                        SetAttribute(crossterm::style::Attribute::NoUnderline),
+                        Print("\x1b]8;;\x07"),
+                    )?;
+                }
+                writer.flush()?;
+            }
 
             if let Event::Key(key) = event::read()? {
                 handle_search_key(&mut app, key)?;

--- a/src/tui/search_app.rs
+++ b/src/tui/search_app.rs
@@ -17,6 +17,14 @@ pub enum ListRow {
     Skill { result_idx: usize, grouped: bool },
 }
 
+/// A terminal hyperlink to be applied after each frame draw via OSC 8.
+pub struct Hyperlink {
+    pub x: u16,
+    pub y: u16,
+    pub text: String,
+    pub url: String,
+}
+
 pub struct SearchApp {
     pub results: Vec<SearchResult>,
     pub rows: Vec<ListRow>,
@@ -25,6 +33,8 @@ pub struct SearchApp {
     pub visible_height: usize,
     pub should_quit: bool,
     pub should_install: bool,
+    /// Hyperlinks to emit after each frame draw.
+    pub hyperlinks: Vec<Hyperlink>,
 }
 
 impl SearchApp {
@@ -41,6 +51,7 @@ impl SearchApp {
             visible_height: 0,
             should_quit: false,
             should_install: false,
+            hyperlinks: Vec::new(),
         }
     }
 

--- a/src/tui/search_ui.rs
+++ b/src/tui/search_ui.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::{Block, Borders, Paragraph};
 
 use ion_skill::search::skill_dir_name;
 
-use super::search_app::{ListRow, SearchApp};
+use super::search_app::{Hyperlink, ListRow, SearchApp};
 use super::util::wrap_text;
 
 const LABEL_STYLE: Style = Style::new().fg(Color::Cyan).add_modifier(Modifier::BOLD);
@@ -25,6 +25,7 @@ fn source_url(registry: &str, source: &str) -> String {
 }
 
 pub fn render_search(frame: &mut Frame, app: &mut SearchApp) {
+    app.hyperlinks.clear();
     let area = frame.area();
 
     let chunks = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
@@ -154,25 +155,28 @@ fn render_list(frame: &mut Frame, app: &SearchApp, area: Rect) {
     frame.render_widget(paragraph, inner);
 }
 
-fn render_detail(frame: &mut Frame, app: &SearchApp, area: Rect) {
+fn render_detail(frame: &mut Frame, app: &mut SearchApp, area: Rect) {
     let block = Block::default().borders(Borders::ALL).title(" Details ");
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let Some(row) = app.rows.get(app.selected) else {
+    let Some(selected) = app.rows.get(app.selected) else {
         let msg = Paragraph::new("No result selected.").style(Style::default().fg(Color::DarkGray));
         frame.render_widget(msg, inner);
         return;
     };
 
-    match row {
-        ListRow::Skill { result_idx, .. } => render_skill_detail(frame, app, inner, *result_idx),
-        ListRow::RepoHeader { .. } => render_repo_detail(frame, inner, row),
+    match selected {
+        ListRow::Skill { result_idx, .. } => {
+            let idx = *result_idx;
+            render_skill_detail(frame, app, inner, idx);
+        }
+        ListRow::RepoHeader { .. } => render_repo_detail(frame, app, inner),
     }
 }
 
-fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usize) {
+fn render_skill_detail(frame: &mut Frame, app: &mut SearchApp, area: Rect, idx: usize) {
     let Some(r) = app.results.get(idx) else {
         return;
     };
@@ -183,13 +187,12 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
         .map_or(r.source.as_str(), |(owner, _)| owner);
     let wrap_width = area.width.saturating_sub(2) as usize;
 
+    let source_label = registry_label(&r.registry);
+    let url = source_url(&r.registry, &r.source);
     let mut lines: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("Source: ", LABEL_STYLE),
-            Span::styled(
-                registry_label(&r.registry),
-                Style::new().fg(registry_color(&r.registry)),
-            ),
+            Span::styled(source_label, LINK_STYLE),
         ]),
         Line::from(vec![
             Span::styled("Owner:  ", LABEL_STYLE),
@@ -199,9 +202,6 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
 
     push_metric_lines(&mut lines, r.stars, r.weekly_installs);
     lines.push(Line::from(""));
-
-    let url = source_url(&r.registry, &r.source);
-    push_link_section(&mut lines, &url, wrap_width);
 
     // Show skill description first (from SKILL.md), then repo description
     if let Some(ref skill_desc) = r.skill_description {
@@ -220,9 +220,18 @@ fn render_skill_detail(frame: &mut Frame, app: &SearchApp, area: Rect, idx: usiz
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, area);
+
+    // Record hyperlink for post-draw OSC 8 emission.
+    // "Source: " is 8 columns, so the label starts at area.x + 8.
+    app.hyperlinks.push(Hyperlink {
+        x: area.x + 8,
+        y: area.y,
+        text: source_label.to_string(),
+        url,
+    });
 }
 
-fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
+fn render_repo_detail(frame: &mut Frame, app: &mut SearchApp, area: Rect) {
     let ListRow::RepoHeader {
         owner_repo,
         stars,
@@ -230,27 +239,33 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
         description,
         skill_count,
         registry,
-    } = row
+    } = &app.rows[app.selected]
     else {
         return;
     };
 
     let owner = owner_repo
         .split_once('/')
-        .map_or(owner_repo.as_str(), |(o, _)| o);
+        .map_or(owner_repo.as_str(), |(o, _)| o)
+        .to_string();
     let wrap_width = area.width.saturating_sub(2) as usize;
+
+    let source_label = registry_label(registry).to_string();
+    let url = source_url(registry, owner_repo);
+    let owner_repo = owner_repo.clone();
+    let stars = *stars;
+    let weekly_installs = *weekly_installs;
+    let description = description.clone();
+    let skill_count = *skill_count;
 
     let mut lines: Vec<Line> = vec![
         Line::from(vec![
             Span::styled("Source:  ", LABEL_STYLE),
-            Span::styled(
-                registry_label(registry),
-                Style::new().fg(registry_color(registry)),
-            ),
+            Span::styled(source_label.clone(), LINK_STYLE),
         ]),
         Line::from(vec![
             Span::styled("Repo:    ", LABEL_STYLE),
-            Span::styled(owner_repo.as_str(), VALUE_STYLE),
+            Span::styled(owner_repo.clone(), VALUE_STYLE),
         ]),
         Line::from(vec![
             Span::styled("Owner:   ", LABEL_STYLE),
@@ -258,17 +273,14 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
         ]),
     ];
 
-    push_metric_lines(&mut lines, *stars, *weekly_installs);
+    push_metric_lines(&mut lines, stars, weekly_installs);
 
     lines.push(Line::from(vec![
         Span::styled("Skills:  ", LABEL_STYLE),
         Span::styled(skill_count.to_string(), VALUE_STYLE),
     ]));
 
-    let url = source_url(registry, owner_repo);
-    push_link_section(&mut lines, &url, wrap_width);
-
-    push_wrapped_section(&mut lines, "Description:", description, wrap_width);
+    push_wrapped_section(&mut lines, "Description:", &description, wrap_width);
 
     lines.push(Line::from(Span::styled("Install all:", LABEL_STYLE)));
     lines.push(Line::from(Span::styled(
@@ -278,6 +290,15 @@ fn render_repo_detail(frame: &mut Frame, area: Rect, row: &ListRow) {
 
     let paragraph = Paragraph::new(lines);
     frame.render_widget(paragraph, area);
+
+    // Record hyperlink for post-draw OSC 8 emission.
+    // "Source:  " is 9 columns.
+    app.hyperlinks.push(Hyperlink {
+        x: area.x + 9,
+        y: area.y,
+        text: source_label,
+        url,
+    });
 }
 
 /// Append a labeled wrapped-text section to `lines` if text is non-empty.
@@ -304,22 +325,6 @@ fn push_styled_section<'a>(
     lines.push(Line::from(Span::styled(label, LABEL_STYLE)));
     for wrapped_line in wrap_text(text, wrap_width) {
         lines.push(Line::from(Span::styled(format!("  {wrapped_line}"), style)));
-    }
-    lines.push(Line::from(""));
-}
-
-/// Append a link section with character-level wrapping (URLs have no spaces).
-fn push_link_section(lines: &mut Vec<Line<'_>>, url: &str, wrap_width: usize) {
-    if url.is_empty() {
-        return;
-    }
-    lines.push(Line::from(Span::styled("Link:", LABEL_STYLE)));
-    let indent = 2;
-    let usable = wrap_width.saturating_sub(indent);
-    for chunk in url.as_bytes().chunks(usable.max(1)) {
-        let s = std::str::from_utf8(chunk).unwrap_or("");
-        let pad = " ".repeat(indent);
-        lines.push(Line::from(Span::styled(format!("{pad}{s}"), LINK_STYLE)));
     }
     lines.push(Line::from(""));
 }


### PR DESCRIPTION
## Summary
- Trim whitespace from skills.sh API `source`/`name`/`skillId` fields to fix leading-space-in-URL bug
- TUI: make Source label (e.g. "skills.sh") a real clickable terminal hyperlink via OSC 8 sequences emitted after ratatui `draw()` — ratatui doesn't support hyperlinks natively, so we re-print the link text wrapped in OSC 8 open/close at known positions
- Non-TUI (agent/pipe): show explicit URL as plain text instead of OSC 8 links
- Remove separate "Link:" section from TUI detail panel

## Test plan
- [x] `cargo fmt --all` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes  
- [x] `cargo nextest run` — 305 tests pass including 2 new whitespace trimming tests
- [ ] Manual: `ion search rust` in TUI — "skills.sh" on Source line is clickable in terminals supporting OSC 8 (iTerm2, Kitty, WezTerm)
- [ ] Manual: `ion search rust | cat` — shows explicit URL as plain text

🤖 Generated with [Claude Code](https://claude.com/claude-code)