### PR TITLE
fix: repair broken deployments during update and support local skill paths

### DIFF
--- a/crates/ion-skill/src/installer.rs
+++ b/crates/ion-skill/src/installer.rs
@@ -200,6 +200,22 @@ impl<'a> SkillInstaller<'a> {
         Ok((meta, body))
     }
 
+    /// Check whether a skill is fully deployed: its canonical directory exists
+    /// and all configured target symlinks are in place and resolve to valid paths.
+    pub fn is_deployed(&self, name: &str) -> bool {
+        let skill_dir = self.skill_dir(name);
+        if !skill_dir.exists() {
+            return false;
+        }
+        for target_path in self.options.targets.values() {
+            let target_dir = self.project_dir.join(target_path).join(name);
+            if !target_dir.exists() {
+                return false;
+            }
+        }
+        true
+    }
+
     pub fn deploy(&self, name: &str, skill_dir: &Path) -> Result<()> {
         let agents_target = self.skill_dir(name);
 
@@ -637,6 +653,93 @@ mod tests {
             targets: std::collections::BTreeMap::new(),
             skills_dir: None,
         }
+    }
+
+    fn options_with_targets() -> ManifestOptions {
+        let mut targets = std::collections::BTreeMap::new();
+        targets.insert("claude".to_string(), ".claude/skills".to_string());
+        ManifestOptions {
+            targets,
+            skills_dir: None,
+        }
+    }
+
+    #[test]
+    fn is_deployed_true_when_all_exist() {
+        let project = tempfile::tempdir().unwrap();
+        let options = options_with_targets();
+
+        // Create skill dir and target symlink
+        let skill_dir = project.path().join(".agents/skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "x").unwrap();
+        let claude_dir = project.path().join(".claude/skills");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            std::path::Path::new("../../.agents/skills/my-skill"),
+            claude_dir.join("my-skill"),
+        )
+        .unwrap();
+
+        let installer = SkillInstaller::new(project.path(), &options);
+        assert!(installer.is_deployed("my-skill"));
+    }
+
+    #[test]
+    fn is_deployed_false_when_skill_dir_missing() {
+        let project = tempfile::tempdir().unwrap();
+        let options = options_with_targets();
+
+        let installer = SkillInstaller::new(project.path(), &options);
+        assert!(!installer.is_deployed("nonexistent"));
+    }
+
+    #[test]
+    fn is_deployed_false_when_target_symlink_missing() {
+        let project = tempfile::tempdir().unwrap();
+        let options = options_with_targets();
+
+        // Create skill dir but no target symlink
+        let skill_dir = project.path().join(".agents/skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(skill_dir.join("SKILL.md"), "x").unwrap();
+
+        let installer = SkillInstaller::new(project.path(), &options);
+        assert!(!installer.is_deployed("my-skill"));
+    }
+
+    #[test]
+    fn is_deployed_false_when_symlink_dangling() {
+        let project = tempfile::tempdir().unwrap();
+        let options = options_with_targets();
+
+        // Create a dangling symlink for the target
+        let claude_dir = project.path().join(".claude/skills");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            std::path::Path::new("../../.agents/skills/my-skill"),
+            claude_dir.join("my-skill"),
+        )
+        .unwrap();
+        // .agents/skills/my-skill does NOT exist, so both the skill_dir and target are broken
+
+        let installer = SkillInstaller::new(project.path(), &options);
+        assert!(!installer.is_deployed("my-skill"));
+    }
+
+    #[test]
+    fn is_deployed_true_with_no_targets() {
+        let project = tempfile::tempdir().unwrap();
+        let options = empty_options();
+
+        // Only need the skill dir when there are no targets
+        let skill_dir = project.path().join(".agents/skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        let installer = SkillInstaller::new(project.path(), &options);
+        assert!(installer.is_deployed("my-skill"));
     }
 
     #[test]

--- a/crates/ion-skill/src/update/binary.rs
+++ b/crates/ion-skill/src/update/binary.rs
@@ -68,6 +68,10 @@ impl Updater for BinaryUpdater {
             asset_pattern.as_deref(),
         )?;
 
+        // Deploy target symlinks (skill_dir == agents_target for binaries,
+        // so this only creates the target symlinks like .claude/skills/{name})
+        installer.deploy(&skill.name, &skill_dir)?;
+
         // Clean up old version if different
         if let Some(old_version) = skill.binary_version()
             && old_version != result.version

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -70,8 +70,13 @@ pub fn run(json: bool, allow_warnings: bool, project_flags: &[String]) -> anyhow
             let source = entry.resolve()?;
 
             if source.is_local() {
-                let skills_dir = merged_options.skills_dir_or_default();
-                let local_skill_dir = project.dir.join(skills_dir).join(name);
+                // Use explicit path from Ion.toml if set, otherwise fall back to skills-dir
+                let local_skill_dir = if let Some(ref path) = source.path {
+                    project.dir.join(path)
+                } else {
+                    let skills_dir = merged_options.skills_dir_or_default();
+                    project.dir.join(skills_dir).join(name)
+                };
 
                 if !local_skill_dir.exists() {
                     println!(

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -393,7 +393,14 @@ pub fn run(
         let cwd = std::env::current_dir()?;
         let manifest_path = cwd.join("Ion.toml");
         if manifest_path.exists() {
-            let source = SkillSource::local();
+            // Record the path relative to the project root so install can find it
+            // even when it differs from skills-dir
+            let rel_path = target_dir
+                .strip_prefix(&cwd)
+                .ok()
+                .map(|p| p.display().to_string());
+            let mut source = SkillSource::local();
+            source.path = rel_path;
             manifest_writer::add_skill(&manifest_path, &name, &source)?;
 
             if json {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -37,6 +37,12 @@ pub fn run(name: Option<&str>, json: bool, project_flags: &[String]) -> anyhow::
         let options = ws.merged_options_for(project)?;
         let installer = ws.installer_for(project, &options);
 
+        // Ensure built-in skill and agent symlinks are up to date (non-fatal)
+        ws.ensure_builtin_skill(project, &options);
+        if let Err(e) = ion_skill::agents::ensure_agent_symlinks(&project.dir, &options.targets) {
+            log::warn!("Failed to create agent symlinks: {e}");
+        }
+
         if multi && !json {
             let label = project_label(project, &ws);
             println!("\n{}:", p.bold(&label));
@@ -269,26 +275,31 @@ fn update_project_skills(
         });
 
         // Check for update
-        let info = match updater.check(&locked, source) {
-            Ok(Some(info)) => info,
+        let update_info = match updater.check(&locked, source) {
+            Ok(Some(info)) => Some(info),
             Ok(None) => {
-                if !json {
-                    pb_println(
-                        &pb,
-                        format!(
-                            "  {} {}  {}",
-                            p.dim("·"),
-                            p.bold(skill_name),
-                            p.dim("already up to date")
-                        ),
-                    );
+                // Remote is up to date — verify local deployment is intact
+                if installer.is_deployed(skill_name) {
+                    if !json {
+                        pb_println(
+                            &pb,
+                            format!(
+                                "  {} {}  {}",
+                                p.dim("·"),
+                                p.bold(skill_name),
+                                p.dim("already up to date")
+                            ),
+                        );
+                    }
+                    json_up_to_date.push(serde_json::json!({ "name": skill_name }));
+                    up_to_date_count += 1;
+                    if let Some(ref pb) = pb {
+                        pb.inc(1);
+                    }
+                    continue;
                 }
-                json_up_to_date.push(serde_json::json!({ "name": skill_name }));
-                up_to_date_count += 1;
-                if let Some(ref pb) = pb {
-                    pb.inc(1);
-                }
-                continue;
+                // Local deployment is broken — needs repair
+                None
             }
             Err(e) => {
                 if !json {
@@ -311,33 +322,57 @@ fn update_project_skills(
             }
         };
 
-        // Apply update
+        // Apply update or repair
         if let Some(ref pb) = pb {
-            pb.set_message(format!("updating {}", skill_name));
+            let action = if update_info.is_some() {
+                "updating"
+            } else {
+                "repairing"
+            };
+            pb.set_message(format!("{} {}", action, skill_name));
         }
 
         match updater.apply(&locked, source, installer) {
             Ok(new_locked) => {
                 if !json {
-                    let binary_suffix = if source.is_binary() { " (binary)" } else { "" };
-                    pb_println(
-                        &pb,
-                        format!(
-                            "  {} {}  {} → {}{}",
-                            p.success("✓"),
-                            p.bold(skill_name),
-                            info.old_version,
-                            p.info(&info.new_version),
-                            binary_suffix
-                        ),
-                    );
+                    if let Some(ref info) = update_info {
+                        let binary_suffix = if source.is_binary() { " (binary)" } else { "" };
+                        pb_println(
+                            &pb,
+                            format!(
+                                "  {} {}  {} → {}{}",
+                                p.success("✓"),
+                                p.bold(skill_name),
+                                info.old_version,
+                                p.info(&info.new_version),
+                                binary_suffix
+                            ),
+                        );
+                    } else {
+                        pb_println(
+                            &pb,
+                            format!(
+                                "  {} {}  {}",
+                                p.success("✓"),
+                                p.bold(skill_name),
+                                p.info("repaired")
+                            ),
+                        );
+                    }
                 }
-                json_updated.push(serde_json::json!({
-                    "name": skill_name,
-                    "old_version": info.old_version,
-                    "new_version": info.new_version,
-                    "binary": source.is_binary(),
-                }));
+                if let Some(ref info) = update_info {
+                    json_updated.push(serde_json::json!({
+                        "name": skill_name,
+                        "old_version": info.old_version,
+                        "new_version": info.new_version,
+                        "binary": source.is_binary(),
+                    }));
+                } else {
+                    json_updated.push(serde_json::json!({
+                        "name": skill_name,
+                        "repaired": true,
+                    }));
+                }
                 lockfile.upsert(new_locked);
                 updated_count += 1;
             }

--- a/tests/update_integration.rs
+++ b/tests/update_integration.rs
@@ -83,6 +83,50 @@ fn read_lockfile(project: &std::path::Path) -> ion_skill::lockfile::Lockfile {
     ion_skill::lockfile::Lockfile::from_file(&project.join("Ion.lock")).unwrap()
 }
 
+/// Set up a project with a git skill installed and ready for update tests.
+/// Returns (upstream_path, project_path, initial_commit).
+fn setup_installed_git_skill(
+    tmp: &std::path::Path,
+    skill_name: &str,
+) -> (std::path::PathBuf, std::path::PathBuf, String) {
+    let upstream = tmp.join("upstream");
+    let project = tmp.join("project");
+    std::fs::create_dir_all(&project).unwrap();
+
+    create_upstream_repo(&upstream, skill_name);
+
+    std::fs::write(
+        project.join("Ion.toml"),
+        format!(
+            "[options]\n\n[options.targets]\nclaude = \".claude/skills\"\n\n[skills]\n{skill_name} = {{ type = \"git\", source = \"{}\" }}\n",
+            upstream.display()
+        ),
+    )
+    .unwrap();
+
+    let output = ion_cmd()
+        .args(["add"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "install failed: stdout={stdout}\nstderr={stderr}"
+    );
+
+    let lock = read_lockfile(&project);
+    let commit = lock
+        .find(skill_name)
+        .expect("skill in lockfile")
+        .commit()
+        .expect("commit")
+        .to_string();
+
+    (upstream, project, commit)
+}
+
 #[test]
 fn update_git_skill_pulls_latest_commit() {
     let tmp = tempfile::tempdir().unwrap();
@@ -340,5 +384,121 @@ fn update_preserves_old_version_on_validation_failure() {
     assert_eq!(
         commit_before, commit_after,
         "lockfile commit should be unchanged when validation fails"
+    );
+}
+
+#[test]
+fn update_repairs_deleted_agents_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_upstream, project, _commit_before) =
+        setup_installed_git_skill(tmp.path(), "repair-skill");
+
+    // Verify initial deployment
+    assert!(project.join(".agents/skills/repair-skill").exists());
+    assert!(project.join(".claude/skills/repair-skill").exists());
+
+    // Delete the .agents directory to simulate corruption
+    std::fs::remove_dir_all(project.join(".agents")).unwrap();
+    assert!(!project.join(".agents/skills/repair-skill").exists());
+
+    // Run `ion update` — should restore the deployment
+    let output = ion_cmd()
+        .args(["update"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "update failed: stdout={stdout}\nstderr={stderr}"
+    );
+
+    // Should report either "repaired" (repair path) or "updated" (re-install path)
+    assert!(
+        stdout.contains("repaired") || stdout.contains("updated"),
+        "expected skill to be repaired or updated, got: {stdout}"
+    );
+
+    // Verify deployment is restored
+    assert!(
+        project.join(".agents/skills/repair-skill").exists(),
+        ".agents/skills/repair-skill should be restored"
+    );
+    assert!(
+        project.join(".claude/skills/repair-skill").exists(),
+        ".claude/skills/repair-skill should be restored"
+    );
+}
+
+#[test]
+fn update_repairs_deleted_target_symlink() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_upstream, project, _commit) = setup_installed_git_skill(tmp.path(), "target-repair");
+
+    // Delete only the target symlink, leaving .agents intact
+    let target = project.join(".claude/skills/target-repair");
+    assert!(target.exists());
+    std::fs::remove_file(&target).unwrap();
+    assert!(!target.exists());
+
+    // .agents dir should still be there
+    assert!(project.join(".agents/skills/target-repair").exists());
+
+    // Run `ion update`
+    let output = ion_cmd()
+        .args(["update"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "update failed: stdout={stdout}\nstderr={stderr}"
+    );
+
+    // Should report either "repaired" or "updated"
+    assert!(
+        stdout.contains("repaired") || stdout.contains("updated"),
+        "expected skill to be repaired or updated, got: {stdout}"
+    );
+
+    // Target symlink should be restored
+    assert!(
+        target.exists(),
+        ".claude/skills/target-repair should be restored"
+    );
+}
+
+#[test]
+fn install_all_repairs_deleted_agents_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let (_upstream, project, _commit) = setup_installed_git_skill(tmp.path(), "install-repair");
+
+    // Delete .agents
+    std::fs::remove_dir_all(project.join(".agents")).unwrap();
+
+    // Run `ion add` (no args = install-all)
+    let output = ion_cmd()
+        .args(["add"])
+        .current_dir(&project)
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "install failed: stdout={stdout}\nstderr={stderr}"
+    );
+
+    // Verify deployment is restored
+    assert!(
+        project.join(".agents/skills/install-repair").exists(),
+        ".agents/skills/install-repair should be restored"
+    );
+    assert!(
+        project.join(".claude/skills/install-repair").exists(),
+        ".claude/skills/install-repair should be restored"
     );
 }


### PR DESCRIPTION
## Summary
- `ion update` now detects missing/broken symlinks and re-deploys skills even when the remote hasn't changed, reporting them as "repaired"
- `ion update` ensures built-in skill and agent symlinks are refreshed each run (matching `ion add`/`init` behavior)
- `BinaryUpdater::apply()` now calls `deploy()` to refresh target symlinks after downloading
- Local skills with explicit `path` in Ion.toml are resolved from that path instead of requiring them to be under `skills-dir`, enabling separation of local (git-tracked) and remote (gitignored) skill directories
- `ion skill new --path` records the relative path in Ion.toml

## Test plan
- [x] 5 unit tests for `is_deployed()` (all exist, missing skill dir, missing target, dangling symlink, no targets)
- [x] 3 integration tests: `update_repairs_deleted_agents_dir`, `update_repairs_deleted_target_symlink`, `install_all_repairs_deleted_agents_dir`
- [x] All 308 existing tests pass
- [x] Verified manually on a real project (ppvm) with custom skills-dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)