### PR TITLE
feat(scenario): add visible_screen() to get terminal display state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2396,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "toml",
+ "vte 0.15.0",
 ]
 
 [[package]]
@@ -2673,7 +2680,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
- "vte",
+ "vte 0.14.1",
 ]
 
 [[package]]
@@ -3239,6 +3246,16 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
 dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "vte"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
+dependencies = [
+ "arrayvec",
  "memchr",
 ]
 

--- a/crates/scenario/Cargo.toml
+++ b/crates/scenario/Cargo.toml
@@ -17,6 +17,7 @@ insta = { version = "1", features = ["filters"], optional = true }
 insta-cmd = { version = "0.6", optional = true }
 minijinja = "2"
 tempfile = "3"
+vte = "0.15"
 toml = "1"
 serde = { version = "1", features = ["derive"] }
 globset = "0.4"

--- a/crates/scenario/src/lib.rs
+++ b/crates/scenario/src/lib.rs
@@ -41,10 +41,12 @@ pub mod manifest;
 mod output;
 mod project;
 mod scenario;
+pub mod screen;
 mod session;
 
 pub use error::Error;
 pub use output::Output;
 pub use project::{Project, ProjectBuilder};
 pub use scenario::{Scenario, Terminal};
+pub use screen::ScreenBuffer;
 pub use session::Session;

--- a/crates/scenario/src/scenario.rs
+++ b/crates/scenario/src/scenario.rs
@@ -393,6 +393,8 @@ impl Scenario {
             state,
             reader_thread,
             self.timeout,
+            rows,
+            cols,
         ))
     }
 }

--- a/crates/scenario/src/screen.rs
+++ b/crates/scenario/src/screen.rs
@@ -1,0 +1,331 @@
+use vte::{Params, Perform};
+
+/// A virtual terminal screen buffer that interprets ANSI escape sequences.
+///
+/// Maintains a grid of characters representing what would be visible on
+/// a terminal of the given dimensions after processing raw PTY output.
+pub struct ScreenBuffer {
+    grid: Vec<Vec<char>>,
+    cursor_row: usize,
+    cursor_col: usize,
+    rows: usize,
+    cols: usize,
+}
+
+impl ScreenBuffer {
+    /// Create a new empty screen buffer with the given dimensions.
+    pub fn new(rows: usize, cols: usize) -> Self {
+        ScreenBuffer {
+            grid: vec![vec![' '; cols]; rows],
+            cursor_row: 0,
+            cursor_col: 0,
+            rows,
+            cols,
+        }
+    }
+
+    /// Feed raw PTY output through the VT parser, updating the grid.
+    pub fn process(&mut self, raw_bytes: &[u8]) {
+        let mut parser = vte::Parser::new();
+        parser.advance(self, raw_bytes);
+    }
+
+    /// Return the current screen content, one `String` per row,
+    /// with trailing spaces trimmed.
+    pub fn lines(&self) -> Vec<String> {
+        self.grid
+            .iter()
+            .map(|row| {
+                let s: String = row.iter().collect();
+                s.trim_end().to_string()
+            })
+            .collect()
+    }
+
+    fn scroll_up(&mut self) {
+        self.grid.remove(0);
+        self.grid.push(vec![' '; self.cols]);
+    }
+
+    fn clear_line_from_cursor(&mut self) {
+        for col in self.cursor_col..self.cols {
+            self.grid[self.cursor_row][col] = ' ';
+        }
+    }
+
+    fn clear_line_to_cursor(&mut self) {
+        for col in 0..=self.cursor_col.min(self.cols - 1) {
+            self.grid[self.cursor_row][col] = ' ';
+        }
+    }
+
+    fn clear_whole_line(&mut self) {
+        for col in 0..self.cols {
+            self.grid[self.cursor_row][col] = ' ';
+        }
+    }
+
+    fn clear_screen(&mut self) {
+        for row in 0..self.rows {
+            for col in 0..self.cols {
+                self.grid[row][col] = ' ';
+            }
+        }
+    }
+
+    fn clear_screen_from_cursor(&mut self) {
+        // Clear from cursor to end of current line
+        self.clear_line_from_cursor();
+        // Clear all lines below
+        for row in (self.cursor_row + 1)..self.rows {
+            for col in 0..self.cols {
+                self.grid[row][col] = ' ';
+            }
+        }
+    }
+
+    fn clear_screen_to_cursor(&mut self) {
+        // Clear from start of screen to cursor
+        for row in 0..self.cursor_row {
+            for col in 0..self.cols {
+                self.grid[row][col] = ' ';
+            }
+        }
+        self.clear_line_to_cursor();
+    }
+}
+
+impl Perform for ScreenBuffer {
+    fn print(&mut self, c: char) {
+        if self.cursor_row < self.rows && self.cursor_col < self.cols {
+            self.grid[self.cursor_row][self.cursor_col] = c;
+            self.cursor_col += 1;
+            if self.cursor_col >= self.cols {
+                self.cursor_col = 0;
+                if self.cursor_row + 1 >= self.rows {
+                    self.scroll_up();
+                } else {
+                    self.cursor_row += 1;
+                }
+            }
+        }
+    }
+
+    fn execute(&mut self, byte: u8) {
+        match byte {
+            // Backspace
+            0x08 => {
+                if self.cursor_col > 0 {
+                    self.cursor_col -= 1;
+                }
+            }
+            // Tab
+            0x09 => {
+                let next_tab = (self.cursor_col / 8 + 1) * 8;
+                self.cursor_col = next_tab.min(self.cols - 1);
+            }
+            // Newline (line feed)
+            0x0A => {
+                if self.cursor_row + 1 >= self.rows {
+                    self.scroll_up();
+                } else {
+                    self.cursor_row += 1;
+                }
+            }
+            // Carriage return
+            0x0D => {
+                self.cursor_col = 0;
+            }
+            _ => {}
+        }
+    }
+
+    fn hook(&mut self, _params: &Params, _intermediates: &[u8], _ignore: bool, _action: char) {}
+    fn put(&mut self, _byte: u8) {}
+    fn unhook(&mut self) {}
+    fn osc_dispatch(&mut self, _params: &[&[u8]], _bell_terminated: bool) {}
+    fn esc_dispatch(&mut self, _intermediates: &[u8], _ignore: bool, _byte: u8) {}
+
+    fn csi_dispatch(
+        &mut self,
+        params: &Params,
+        _intermediates: &[u8],
+        _ignore: bool,
+        action: char,
+    ) {
+        let params: Vec<u16> = params.iter().map(|p| p[0]).collect();
+
+        match action {
+            // Cursor Up
+            'A' => {
+                let n = params.first().copied().unwrap_or(1).max(1) as usize;
+                self.cursor_row = self.cursor_row.saturating_sub(n);
+            }
+            // Cursor Down
+            'B' => {
+                let n = params.first().copied().unwrap_or(1).max(1) as usize;
+                self.cursor_row = (self.cursor_row + n).min(self.rows - 1);
+            }
+            // Cursor Forward
+            'C' => {
+                let n = params.first().copied().unwrap_or(1).max(1) as usize;
+                self.cursor_col = (self.cursor_col + n).min(self.cols - 1);
+            }
+            // Cursor Back
+            'D' => {
+                let n = params.first().copied().unwrap_or(1).max(1) as usize;
+                self.cursor_col = self.cursor_col.saturating_sub(n);
+            }
+            // Cursor Position (CUP) / Home
+            'H' | 'f' => {
+                let row = params.first().copied().unwrap_or(1).max(1) as usize;
+                let col = params.get(1).copied().unwrap_or(1).max(1) as usize;
+                self.cursor_row = (row - 1).min(self.rows - 1);
+                self.cursor_col = (col - 1).min(self.cols - 1);
+            }
+            // Erase in Display
+            'J' => {
+                let mode = params.first().copied().unwrap_or(0);
+                match mode {
+                    0 => self.clear_screen_from_cursor(),
+                    1 => self.clear_screen_to_cursor(),
+                    2 | 3 => self.clear_screen(),
+                    _ => {}
+                }
+            }
+            // Erase in Line
+            'K' => {
+                let mode = params.first().copied().unwrap_or(0);
+                match mode {
+                    0 => self.clear_line_from_cursor(),
+                    1 => self.clear_line_to_cursor(),
+                    2 => self.clear_whole_line(),
+                    _ => {}
+                }
+            }
+            // SGR (colors/styles) - ignore
+            'm' => {}
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_text_output() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Hello, world!");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "Hello, world!");
+        assert_eq!(lines[1], "");
+    }
+
+    #[test]
+    fn test_newline() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Line 1\r\nLine 2");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "Line 1");
+        assert_eq!(lines[1], "Line 2");
+    }
+
+    #[test]
+    fn test_cursor_position() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        // Move to row 2, col 5 (1-based) then write
+        screen.process(b"\x1b[2;5HWorld");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "");
+        assert_eq!(lines[1], "    World");
+    }
+
+    #[test]
+    fn test_cursor_home() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"XXXXX\x1b[HHello");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "Hello");
+    }
+
+    #[test]
+    fn test_cursor_movement() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"ABCDEF\x1b[3DX");
+        let lines = screen.lines();
+        // "ABCDEF", then move left 3, write X over 'D'
+        assert_eq!(lines[0], "ABCXEF");
+    }
+
+    #[test]
+    fn test_clear_to_end_of_line() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Hello, world!\x1b[1;6H\x1b[K");
+        let lines = screen.lines();
+        // Cursor at col 6 (1-based) = col 5 (0-based), clear from there
+        assert_eq!(lines[0], "Hello");
+    }
+
+    #[test]
+    fn test_clear_whole_line() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Hello, world!\x1b[2K");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "");
+    }
+
+    #[test]
+    fn test_clear_screen() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Line 1\r\nLine 2\x1b[2J");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "");
+        assert_eq!(lines[1], "");
+    }
+
+    #[test]
+    fn test_carriage_return_overwrites() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Hello!\rWorld");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "World!");
+    }
+
+    #[test]
+    fn test_backspace() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"ABC\x08X");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "ABX");
+    }
+
+    #[test]
+    fn test_sgr_codes_ignored() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"\x1b[31mRed\x1b[0m Normal");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "Red Normal");
+    }
+
+    #[test]
+    fn test_scroll_up() {
+        let mut screen = ScreenBuffer::new(3, 10);
+        screen.process(b"Line 1\r\nLine 2\r\nLine 3\r\nLine 4");
+        let lines = screen.lines();
+        // Line 1 should have scrolled off
+        assert_eq!(lines[0], "Line 2");
+        assert_eq!(lines[1], "Line 3");
+        assert_eq!(lines[2], "Line 4");
+    }
+
+    #[test]
+    fn test_line_wrap() {
+        let mut screen = ScreenBuffer::new(3, 5);
+        screen.process(b"ABCDEFGH");
+        let lines = screen.lines();
+        assert_eq!(lines[0], "ABCDE");
+        assert_eq!(lines[1], "FGH");
+    }
+}

--- a/crates/scenario/src/session.rs
+++ b/crates/scenario/src/session.rs
@@ -8,6 +8,7 @@ use regex::Regex;
 
 use crate::error::Error;
 use crate::output::Output;
+use crate::screen::ScreenBuffer;
 
 /// Shared state between the reader thread and the session.
 pub(crate) struct ReaderState {
@@ -55,9 +56,12 @@ pub struct Session {
     reader_thread: Option<JoinHandle<()>>,
     timeout: Duration,
     expect_pos: usize,
+    rows: u16,
+    cols: u16,
 }
 
 impl Session {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         writer: Box<dyn Write + Send>,
         child: Box<dyn portable_pty::Child + Send + Sync>,
@@ -65,6 +69,8 @@ impl Session {
         state: Arc<Mutex<ReaderState>>,
         reader_thread: JoinHandle<()>,
         timeout: Duration,
+        rows: u16,
+        cols: u16,
     ) -> Self {
         Session {
             writer: Some(writer),
@@ -74,6 +80,8 @@ impl Session {
             reader_thread: Some(reader_thread),
             timeout,
             expect_pos: 0,
+            rows,
+            cols,
         }
     }
 
@@ -165,7 +173,7 @@ impl Session {
     }
 
     /// Resize the terminal.
-    pub fn resize(&self, cols: u16, rows: u16) -> Result<(), Error> {
+    pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), Error> {
         self.master
             .resize(PtySize {
                 rows,
@@ -173,7 +181,27 @@ impl Session {
                 pixel_width: 0,
                 pixel_height: 0,
             })
-            .map_err(|e| Error::Pty(e.to_string()))
+            .map_err(|e| Error::Pty(e.to_string()))?;
+        self.rows = rows;
+        self.cols = cols;
+        Ok(())
+    }
+
+    /// Get the current PTY dimensions as `(rows, cols)`.
+    pub fn pty_size(&self) -> (usize, usize) {
+        (self.rows as usize, self.cols as usize)
+    }
+
+    /// Get the current terminal screen content as a grid of lines.
+    ///
+    /// Interprets ANSI escape sequences to determine what would actually
+    /// be visible on screen. Returns one `String` per terminal row.
+    pub fn visible_screen(&self) -> Vec<String> {
+        let state = self.state.lock().unwrap();
+        let (rows, cols) = self.pty_size();
+        let mut screen = ScreenBuffer::new(rows, cols);
+        screen.process(&state.raw);
+        screen.lines()
     }
 
     /// Wait for the process to exit and return the captured output.


### PR DESCRIPTION
## Summary
- Adds `ScreenBuffer` struct with a VT parser (`vte` crate) that interprets ANSI escape sequences to maintain a virtual terminal grid
- Adds `visible_screen()` method to `Session` that returns `Vec<String>` — what the user would actually see on the terminal
- Handles cursor movement, line/screen clearing, carriage return, backspace, tab, scrolling, and line wrapping
- Tracks PTY dimensions in Session (updated on `resize()`)

Closes #123

## Test plan
- [x] 13 unit tests for ScreenBuffer covering basic text, cursor movement, clearing, CR overwrite, backspace, SGR stripping, scrolling, line wrapping
- [x] `cargo fmt`, `cargo clippy`, `cargo nextest run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)