### PR TITLE
[codex] add scenario integration coverage for session helpers

### DIFF
--- a/crates/scenario/tests/expect_not.rs
+++ b/crates/scenario/tests/expect_not.rs
@@ -1,0 +1,59 @@
+use scenario::{Error, Scenario, Terminal};
+
+fn spawn_session(script: &str) -> scenario::Session {
+    Scenario::new("sh")
+        .args(["-c", script])
+        .terminal(Terminal::pty(80, 24))
+        .spawn()
+        .unwrap()
+}
+
+#[test]
+fn expect_not_ignores_already_seen_output() {
+    let mut session = spawn_session("printf '%s\n' 'forbidden before marker' 'ready-marker'");
+
+    session.expect("ready-marker").unwrap();
+    session.expect_not("forbidden").unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_not_fails_when_literal_pattern_appears() {
+    let session = spawn_session("printf '%s\n' 'start forbidden end'");
+
+    let result = session.expect_not("forbidden");
+    assert!(matches!(
+        result,
+        Err(Error::UnexpectedPattern { pattern, buffer })
+        if pattern == "forbidden" && buffer.contains("forbidden")
+    ));
+
+    let _ = session.wait();
+}
+
+#[test]
+fn expect_not_regex_ignores_already_seen_output() {
+    let mut session = spawn_session("printf '%s\n' 'digits 123 before marker' 'ready-marker'");
+
+    session.expect("ready-marker").unwrap();
+    session.expect_not_regex(r"\d+").unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_not_regex_fails_when_pattern_matches() {
+    let session = spawn_session("printf '%s\n' 'version 42'");
+
+    let result = session.expect_not_regex(r"\d+");
+    assert!(matches!(
+        result,
+        Err(Error::UnexpectedPattern { pattern, buffer })
+        if pattern == r"\d+" && buffer.contains("42")
+    ));
+
+    let _ = session.wait();
+}

--- a/crates/scenario/tests/send_key.rs
+++ b/crates/scenario/tests/send_key.rs
@@ -1,0 +1,69 @@
+use std::time::Duration;
+
+use scenario::{Key, Scenario, Terminal};
+
+#[test]
+fn send_key_down_writes_the_arrow_escape_sequence() {
+    let mut session = Scenario::new("sh")
+        .args([
+            "-c",
+            "printf 'ready\\n'; IFS= read -r line; printf '%s' \"$line\" | od -An -tx1",
+        ])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(5))
+        .spawn()
+        .unwrap();
+
+    session.expect("ready").unwrap();
+    session.send_key(Key::Down).unwrap();
+    session.send_key(Key::Enter).unwrap();
+
+    session.expect_regex(r"1b\s+5b\s+42").unwrap();
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn send_key_backspace_edits_the_line_before_submit() {
+    let mut session = Scenario::new("sh")
+        .args([
+            "-c",
+            "printf 'ready\\n'; IFS= read -r line; printf '%s' \"$line\" | od -An -tx1",
+        ])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(5))
+        .spawn()
+        .unwrap();
+
+    session.expect("ready").unwrap();
+    session.send_key(Key::Char('a')).unwrap();
+    session.send_key(Key::Char('b')).unwrap();
+    session.send_key(Key::Backspace).unwrap();
+    session.send_key(Key::Char('c')).unwrap();
+    session.send_key(Key::Enter).unwrap();
+
+    session.expect_regex(r"61\s+63").unwrap();
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn send_key_ctrl_c_interrupts_the_foreground_process() {
+    let mut session = Scenario::new("sh")
+        .args([
+            "-c",
+            "trap 'printf trapped\\n; exit 130' INT; printf ready\\n; while :; do sleep 1; done",
+        ])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(5))
+        .spawn()
+        .unwrap();
+
+    session.expect("ready").unwrap();
+    session.send_key(Key::CtrlC).unwrap();
+    session.expect("trapped").unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(!output.success());
+    assert_eq!(output.exit_code(), 130);
+}

--- a/crates/scenario/tests/visible_screen.rs
+++ b/crates/scenario/tests/visible_screen.rs
@@ -1,0 +1,51 @@
+use std::time::Duration;
+
+use scenario::{Scenario, Terminal};
+
+#[test]
+fn visible_screen_keeps_only_the_latest_single_line_redraw() {
+    let mut session = Scenario::new("sh")
+        .args([
+            "-c",
+            r#"printf 'Option A'; printf '\r\033[K'; printf '> Option B'; sleep 0.1"#,
+        ])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(2))
+        .spawn()
+        .unwrap();
+
+    session.expect("> Option B").unwrap();
+
+    let current_output = session.current_output();
+    assert!(current_output.contains("Option A"));
+    assert!(current_output.contains("> Option B"));
+
+    let screen = session.visible_screen();
+    assert_eq!(screen[0], "> Option B");
+    assert!(screen[1..].iter().all(|line| line.is_empty()));
+}
+
+#[test]
+fn visible_screen_reflects_in_place_multiline_redraws() {
+    let mut session = Scenario::new("sh")
+        .args([
+            "-c",
+            r#"printf 'top\nmiddle\nbottom'; printf '\033[1A\r\033[K'; printf 'middle updated'; sleep 0.1"#,
+        ])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(2))
+        .spawn()
+        .unwrap();
+
+    session.expect("middle updated").unwrap();
+
+    let current_output = session.current_output();
+    assert!(current_output.contains("middle\n"));
+    assert!(current_output.contains("middle updated"));
+
+    let screen = session.visible_screen();
+    assert_eq!(screen[0], "top");
+    assert_eq!(screen[1], "middle updated");
+    assert_eq!(screen[2], "bottom");
+    assert!(screen[3..].iter().all(|line| line.is_empty()));
+}


### PR DESCRIPTION
## Summary

Adds end-to-end integration coverage for the three shipped `scenario` session-helper features:

- `send_key()`
- `visible_screen()`
- `expect_not()` / `expect_not_regex()`

## What changed

- added `crates/scenario/tests/send_key.rs`
  - covers arrow-key escape sequences through the public PTY API
  - covers backspace editing before submit
  - covers `Ctrl-C` interrupt behavior
- added `crates/scenario/tests/visible_screen.rs`
  - verifies visible screen state reflects redraws instead of raw historical PTY output
  - covers single-line and multiline in-place updates
- added `crates/scenario/tests/expect_not.rs`
  - verifies unseen-output semantics
  - covers literal and regex negative assertions

## Why

These APIs were already implemented on `main`, but the issue contracts were not covered end-to-end through the public test surface. This PR closes that gap and makes regressions easier to catch without relying only on unit tests inside implementation modules.

## Validation

- `cargo nextest run -p scenario`
- `cargo fmt --all --check`
- `cargo clippy -p scenario --all-targets --all-features -- -D warnings`

## Notes

The unrelated local `Ion.toml` modification was intentionally left out of this PR.