### PR TITLE
feat(scenario): add CLI flow testing helpers

### DIFF
--- a/crates/scenario/src/error.rs
+++ b/crates/scenario/src/error.rs
@@ -67,6 +67,14 @@ pub enum Error {
     /// A symlink target does not exist after rendering.
     #[error("symlink target does not exist: {}", path.display())]
     SymlinkTarget { path: PathBuf },
+
+    /// Post-build project setup failed.
+    #[error("project setup failed during {step}: {source}")]
+    ProjectSetup {
+        step: String,
+        #[source]
+        source: ProjectSetupError,
+    },
 }
 
 fn format_duration(d: &Duration) -> String {
@@ -77,3 +85,21 @@ fn format_duration(d: &Duration) -> String {
         format!("{secs:.1}s")
     }
 }
+
+/// Human-readable error details for a project setup step.
+#[derive(Debug)]
+pub struct ProjectSetupError(String);
+
+impl ProjectSetupError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for ProjectSetupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ProjectSetupError {}

--- a/crates/scenario/src/lib.rs
+++ b/crates/scenario/src/lib.rs
@@ -49,6 +49,6 @@ pub use error::Error;
 pub use key::Key;
 pub use output::Output;
 pub use project::{Project, ProjectBuilder};
-pub use scenario::{Scenario, Terminal};
+pub use scenario::{Scenario, SessionConfig, Terminal};
 pub use screen::ScreenBuffer;
 pub use session::Session;

--- a/crates/scenario/src/project.rs
+++ b/crates/scenario/src/project.rs
@@ -1,9 +1,12 @@
 //! Project fixture builder for setting up test directory structures.
 
+use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
 use crate::Error;
+use crate::error::ProjectSetupError;
 use crate::manifest::TemplateManifest;
 
 /// A materialized project directory, ready for use in a [`Scenario`](crate::Scenario).
@@ -43,6 +46,9 @@ impl Project {
             overrides: HashMap::new(),
             extra_files: Vec::new(),
             extra_dirs: Vec::new(),
+            git_requested: false,
+            git_user: None,
+            initial_commit_message: None,
         }
     }
 
@@ -56,6 +62,9 @@ impl Project {
             overrides: HashMap::new(),
             extra_files: Vec::new(),
             extra_dirs: Vec::new(),
+            git_requested: false,
+            git_user: None,
+            initial_commit_message: None,
         }
     }
 }
@@ -74,7 +83,18 @@ pub struct ProjectBuilder {
     overrides: HashMap<String, String>,
     extra_files: Vec<(String, String)>,
     extra_dirs: Vec<String>,
+    git_requested: bool,
+    git_user: Option<GitUser>,
+    initial_commit_message: Option<String>,
 }
+
+struct GitUser {
+    name: String,
+    email: String,
+}
+
+const DEFAULT_GIT_USER_NAME: &str = "Scenario Test";
+const DEFAULT_GIT_USER_EMAIL: &str = "scenario@example.com";
 
 impl ProjectBuilder {
     pub fn var(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
@@ -119,6 +139,24 @@ impl ProjectBuilder {
         self
     }
 
+    pub fn setup_git(mut self) -> Self {
+        self.git_requested = true;
+        self
+    }
+
+    pub fn git_user(mut self, name: &str, email: &str) -> Self {
+        self.git_user = Some(GitUser {
+            name: name.to_string(),
+            email: email.to_string(),
+        });
+        self
+    }
+
+    pub fn initial_commit(mut self, message: &str) -> Self {
+        self.initial_commit_message = Some(message.to_string());
+        self
+    }
+
     pub fn build(self) -> Result<Project, Error> {
         let tmp = tempfile::tempdir()?;
         self.build_into(tmp.path())?;
@@ -136,6 +174,8 @@ impl ProjectBuilder {
     }
 
     fn build_into(self, target: &Path) -> Result<(), Error> {
+        let mut tracked_paths = BTreeSet::new();
+
         if let BuilderSource::Template(ref template_dir) = self.source {
             let template_dir = template_dir.clone();
             if !template_dir.exists() {
@@ -225,6 +265,7 @@ impl ProjectBuilder {
                     std::fs::create_dir_all(parent)?;
                 }
                 std::fs::write(&dest, content_rendered)?;
+                tracked_paths.insert(dest_rendered);
             }
 
             // Create symlinks
@@ -262,6 +303,7 @@ impl ProjectBuilder {
                         std::os::windows::fs::symlink_file(&target_rendered, &link_path)?;
                     }
                 }
+                tracked_paths.insert(link_rendered);
             }
         }
 
@@ -272,11 +314,65 @@ impl ProjectBuilder {
                 std::fs::create_dir_all(parent)?;
             }
             std::fs::write(&dest, content)?;
+            tracked_paths.insert(path.clone());
         }
 
         // Create extra dirs
         for dir in &self.extra_dirs {
             std::fs::create_dir_all(target.join(dir))?;
+        }
+
+        self.run_setup_actions(target, &tracked_paths)?;
+
+        Ok(())
+    }
+
+    fn run_setup_actions(
+        &self,
+        target: &Path,
+        tracked_paths: &BTreeSet<String>,
+    ) -> Result<(), Error> {
+        let needs_git =
+            self.git_requested || self.git_user.is_some() || self.initial_commit_message.is_some();
+        if !needs_git {
+            return Ok(());
+        }
+
+        run_git(target, "setup_git", ["init"].as_slice())?;
+
+        if let Some(user) = self.git_user.as_ref() {
+            run_git(
+                target,
+                "git_user",
+                ["config", "user.name", user.name.as_str()].as_slice(),
+            )?;
+            run_git(
+                target,
+                "git_user",
+                ["config", "user.email", user.email.as_str()].as_slice(),
+            )?;
+        } else if self.initial_commit_message.is_some() {
+            run_git(
+                target,
+                "git_user",
+                ["config", "user.name", DEFAULT_GIT_USER_NAME].as_slice(),
+            )?;
+            run_git(
+                target,
+                "git_user",
+                ["config", "user.email", DEFAULT_GIT_USER_EMAIL].as_slice(),
+            )?;
+        }
+
+        if let Some(message) = &self.initial_commit_message {
+            let mut add_args = vec!["add", "--"];
+            add_args.extend(tracked_paths.iter().map(String::as_str));
+            run_git(target, "initial_commit", &add_args)?;
+            run_git(
+                target,
+                "initial_commit",
+                ["commit", "-m", message.as_str()].as_slice(),
+            )?;
         }
 
         Ok(())
@@ -335,6 +431,71 @@ impl ProjectBuilder {
         }
 
         Ok(result)
+    }
+}
+
+fn run_git(target: &Path, step: &str, args: &[&str]) -> Result<(), Error> {
+    run_git_program("git", target, step, args)
+}
+
+fn run_git_program(program: &str, target: &Path, step: &str, args: &[&str]) -> Result<(), Error> {
+    let output = Command::new(program)
+        .arg("-C")
+        .arg(target)
+        .args(args)
+        .output()
+        .map_err(|source| Error::ProjectSetup {
+            step: step.to_string(),
+            source: ProjectSetupError::new(format!(
+                "{} {:?} failed to start: {}",
+                program, args, source
+            )),
+        })?;
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let source = if stderr.is_empty() {
+        format!("{} {:?} exited with {}", program, args, output.status)
+    } else {
+        format!(
+            "{} {:?} exited with {}: {}",
+            program, args, output.status, stderr
+        )
+    };
+
+    Err(Error::ProjectSetup {
+        step: step.to_string(),
+        source: ProjectSetupError::new(source),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+mod tests {
+    use super::run_git_program;
+    use crate::Error;
+
+    #[test]
+    fn run_git_spawn_failure_includes_command_context() {
+        let target = tempfile::tempdir().unwrap();
+        let result = run_git_program(
+            "__scenario_missing_git__",
+            target.path(),
+            "setup_git",
+            ["init"].as_slice(),
+        );
+
+        match result {
+            Err(Error::ProjectSetup { step, source }) => {
+                assert_eq!(step, "setup_git");
+                let message = source.to_string();
+                assert!(message.contains("__scenario_missing_git__ [\"init\"] failed to start"));
+            }
+            other => panic!("expected ProjectSetup error, got: {other:?}"),
+        }
     }
 }
 

--- a/crates/scenario/src/scenario.rs
+++ b/crates/scenario/src/scenario.rs
@@ -31,6 +31,29 @@ impl Terminal {
     }
 }
 
+/// Reusable session settings for interactive scenarios.
+#[derive(Debug, Clone)]
+pub struct SessionConfig {
+    terminal: Terminal,
+    timeout: Duration,
+}
+
+impl SessionConfig {
+    /// Create a PTY session profile with the given column and row count.
+    pub fn pty(cols: u16, rows: u16) -> Self {
+        SessionConfig {
+            terminal: Terminal::pty(cols, rows),
+            timeout: Duration::from_secs(30),
+        }
+    }
+
+    /// Set the timeout for this session profile.
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
 /// Builder for defining a CLI scenario.
 ///
 /// A scenario describes how to run a CLI command under specific terminal
@@ -130,6 +153,13 @@ impl Scenario {
     /// Set the terminal conditions.
     pub fn terminal(mut self, terminal: Terminal) -> Self {
         self.terminal = terminal;
+        self
+    }
+
+    /// Apply a reusable session profile.
+    pub fn session_config(mut self, config: &SessionConfig) -> Self {
+        self.terminal = config.terminal.clone();
+        self.timeout = config.timeout;
         self
     }
 

--- a/crates/scenario/src/session.rs
+++ b/crates/scenario/src/session.rs
@@ -116,6 +116,32 @@ impl Session {
         self.send(&key.to_bytes())
     }
 
+    /// Send multiple terminal keys in order to the process.
+    pub fn send_keys<I>(&mut self, keys: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = Key>,
+    {
+        for key in keys {
+            self.send_key(key)?;
+        }
+        Ok(())
+    }
+
+    /// Send a single terminal key to the process.
+    pub fn press(&mut self, key: Key) -> Result<(), Error> {
+        self.send_key(key)
+    }
+
+    /// Simulate pressing Enter.
+    pub fn enter(&mut self) -> Result<(), Error> {
+        self.send_key(Key::Enter)
+    }
+
+    /// Simulate pressing Ctrl+C.
+    pub fn ctrl_c(&mut self) -> Result<(), Error> {
+        self.send_key(Key::CtrlC)
+    }
+
     /// Send raw bytes to the process.
     pub fn send(&mut self, data: &[u8]) -> Result<(), Error> {
         let writer = self
@@ -286,6 +312,86 @@ impl Session {
         screen.lines()
     }
 
+    /// Get the current terminal screen content as newline-delimited text.
+    pub fn visible_text(&self) -> String {
+        self.visible_screen().join("\n")
+    }
+
+    /// Wait until the current visible screen contains the given string.
+    pub fn expect_screen(&self, pattern: &str) -> Result<(), Error> {
+        self.expect_screen_match(pattern, |visible, pattern| visible.contains(pattern))
+    }
+
+    /// Wait until the current visible screen matches the given regex.
+    pub fn expect_screen_regex(&self, pattern: &str) -> Result<(), Error> {
+        let re = Regex::new(pattern)?;
+        self.expect_screen_match(pattern, |visible, _| re.is_match(visible))
+    }
+
+    /// Assert that the current visible screen does not contain the given string.
+    pub fn expect_screen_not(&self, pattern: &str) -> Result<(), Error> {
+        self.expect_screen_not_timeout(pattern, Duration::from_millis(500))
+    }
+
+    /// Assert that the current visible screen does not contain the given string within the given duration.
+    pub fn expect_screen_not_timeout(
+        &self,
+        pattern: &str,
+        duration: Duration,
+    ) -> Result<(), Error> {
+        self.expect_screen_not_match(pattern, duration, |visible, pattern| {
+            visible.contains(pattern)
+        })
+    }
+
+    /// Assert that the current visible screen does not match the given regex.
+    pub fn expect_screen_not_regex(&self, pattern: &str) -> Result<(), Error> {
+        self.expect_screen_not_regex_timeout(pattern, Duration::from_millis(500))
+    }
+
+    /// Assert that the current visible screen does not match the given regex within the given duration.
+    pub fn expect_screen_not_regex_timeout(
+        &self,
+        pattern: &str,
+        duration: Duration,
+    ) -> Result<(), Error> {
+        let re = Regex::new(pattern)?;
+        self.expect_screen_not_match(pattern, duration, |visible, _| re.is_match(visible))
+    }
+
+    /// Wait until the visible screen is unchanged for the requested quiet period.
+    pub fn wait_for_screen_stable(&self, quiet_period: Duration) -> Result<(), Error> {
+        let deadline = Instant::now() + self.timeout;
+        let mut last_visible = self.visible_text();
+        let mut last_raw_len = self.raw_len();
+        let mut stable_since = if Self::screen_has_content(&last_visible) || last_raw_len > 0 {
+            Some(Instant::now())
+        } else {
+            None
+        };
+
+        loop {
+            thread::sleep(Duration::from_millis(10));
+            let visible = self.visible_text();
+            let raw_len = self.raw_len();
+            if visible != last_visible {
+                last_visible = visible;
+                stable_since = Some(Instant::now());
+            } else if raw_len != last_raw_len {
+                stable_since = Some(Instant::now());
+            } else if let Some(stable_since) = stable_since
+                && Instant::now().duration_since(stable_since) >= quiet_period
+            {
+                return Ok(());
+            }
+            last_raw_len = raw_len;
+
+            if Instant::now() >= deadline {
+                return Err(Error::Timeout(self.timeout));
+            }
+        }
+    }
+
     /// Wait for the process to exit and return the captured output.
     ///
     /// Drops the writer (sending EOF to the child), waits for exit, and
@@ -363,6 +469,59 @@ impl Session {
         strip_ansi_escapes::strip_str(String::from_utf8_lossy(&state.raw))
     }
 
+    fn expect_screen_match<F>(&self, pattern: &str, matches: F) -> Result<(), Error>
+    where
+        F: Fn(&str, &str) -> bool,
+    {
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let visible = self.visible_text();
+            if matches(&visible, pattern) {
+                return Ok(());
+            }
+            if self.is_done() {
+                return Err(Error::ExpectTimeout {
+                    pattern: pattern.to_string(),
+                    timeout: self.timeout,
+                    buffer: visible,
+                });
+            }
+            if Instant::now() >= deadline {
+                return Err(Error::ExpectTimeout {
+                    pattern: pattern.to_string(),
+                    timeout: self.timeout,
+                    buffer: visible,
+                });
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    fn expect_screen_not_match<F>(
+        &self,
+        pattern: &str,
+        quiet_period: Duration,
+        matches: F,
+    ) -> Result<(), Error>
+    where
+        F: Fn(&str, &str) -> bool,
+    {
+        let deadline = Instant::now() + quiet_period;
+        loop {
+            let visible = self.visible_text();
+            if matches(&visible, pattern) {
+                return Err(Error::UnexpectedPattern {
+                    pattern: pattern.to_string(),
+                    buffer: visible,
+                });
+            }
+            if Instant::now() >= deadline || self.is_done() {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     fn unseen_text(&self) -> String {
         let stripped = self.current_stripped();
         if self.expect_pos >= stripped.len() {
@@ -374,6 +533,14 @@ impl Session {
 
     fn is_done(&self) -> bool {
         self.state.lock().unwrap().done
+    }
+
+    fn raw_len(&self) -> usize {
+        self.state.lock().unwrap().raw.len()
+    }
+
+    fn screen_has_content(visible: &str) -> bool {
+        visible.lines().any(|line| !line.trim().is_empty())
     }
 }
 

--- a/crates/scenario/tests/project.rs
+++ b/crates/scenario/tests/project.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::Path;
+use std::process::Command;
 
 use scenario::{Error, Project, Scenario};
 
@@ -88,6 +89,234 @@ fn empty_project_with_nested_file() {
 fn empty_project_with_dir() {
     let project = Project::empty().dir("empty-dir").build().unwrap();
     assert!(project.path().join("empty-dir").is_dir());
+}
+
+#[test]
+fn setup_git_initializes_a_repository() {
+    let project = Project::empty().setup_git().build().unwrap();
+
+    assert!(project.path().join(".git").is_dir());
+
+    let status = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "rev-parse",
+            "--is-inside-work-tree",
+        ])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    assert_eq!(String::from_utf8(status.stdout).unwrap().trim(), "true");
+}
+
+#[test]
+fn initial_commit_creates_head_commit() {
+    let project = Project::empty()
+        .file("README.md", "hello\n")
+        .initial_commit("initial commit")
+        .build()
+        .unwrap();
+
+    let head = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "rev-parse",
+            "--verify",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+    assert_eq!(String::from_utf8(head.stdout).unwrap().trim().len(), 40);
+
+    let message = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "log",
+            "-1",
+            "--format=%s",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(message.status.success());
+    assert_eq!(
+        String::from_utf8(message.stdout).unwrap().trim(),
+        "initial commit"
+    );
+
+    let author = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "log",
+            "-1",
+            "--format=%an <%ae>",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(author.status.success());
+    assert_eq!(
+        String::from_utf8(author.stdout).unwrap().trim(),
+        "Scenario Test <scenario@example.com>"
+    );
+}
+
+#[test]
+fn git_setup_actions_are_order_independent() {
+    let project = Project::empty()
+        .file("README.md", "hello\n")
+        .initial_commit("out of order")
+        .git_user("Ordered User", "ordered@example.com")
+        .setup_git()
+        .build()
+        .unwrap();
+
+    let head = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "rev-parse",
+            "--verify",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(head.status.success());
+
+    let author = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "log",
+            "-1",
+            "--format=%an <%ae>",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(author.status.success());
+    assert_eq!(
+        String::from_utf8(author.stdout).unwrap().trim(),
+        "Ordered User <ordered@example.com>"
+    );
+}
+
+#[test]
+fn build_in_initial_commit_only_tracks_builder_created_content() {
+    let target = tempfile::tempdir().unwrap();
+    fs::write(target.path().join("preexisting.txt"), "leave me alone\n").unwrap();
+
+    let project = Project::empty()
+        .file("managed.txt", "tracked\n")
+        .initial_commit("scoped commit")
+        .build_in(target.path())
+        .unwrap();
+
+    let tracked = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "ls-tree",
+            "--name-only",
+            "-r",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(tracked.status.success());
+    let tracked = String::from_utf8(tracked.stdout).unwrap();
+    assert!(tracked.lines().any(|line| line == "managed.txt"));
+    assert!(!tracked.lines().any(|line| line == "preexisting.txt"));
+
+    let status = Command::new("git")
+        .args(["-C", project.path().to_str().unwrap(), "status", "--short"])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status = String::from_utf8(status.stdout).unwrap();
+    assert!(status.lines().any(|line| line == "?? preexisting.txt"));
+    assert!(!status.lines().any(|line| line.contains("managed.txt")));
+}
+
+#[test]
+fn build_in_initial_commit_does_not_stage_preexisting_nested_files_under_builder_dirs() {
+    let target = tempfile::tempdir().unwrap();
+    fs::create_dir_all(target.path().join("managed")).unwrap();
+    fs::write(
+        target.path().join("managed/preexisting.txt"),
+        "leave nested alone\n",
+    )
+    .unwrap();
+
+    let project = Project::empty()
+        .dir("managed")
+        .file("managed/created.txt", "tracked\n")
+        .initial_commit("nested scope")
+        .build_in(target.path())
+        .unwrap();
+
+    let tracked = Command::new("git")
+        .args([
+            "-C",
+            project.path().to_str().unwrap(),
+            "ls-tree",
+            "--name-only",
+            "-r",
+            "HEAD",
+        ])
+        .output()
+        .unwrap();
+    assert!(tracked.status.success());
+    let tracked = String::from_utf8(tracked.stdout).unwrap();
+    assert!(tracked.lines().any(|line| line == "managed/created.txt"));
+    assert!(
+        !tracked
+            .lines()
+            .any(|line| line == "managed/preexisting.txt")
+    );
+
+    let status = Command::new("git")
+        .args(["-C", project.path().to_str().unwrap(), "status", "--short"])
+        .output()
+        .unwrap();
+    assert!(status.status.success());
+    let status = String::from_utf8(status.stdout).unwrap();
+    assert!(
+        status
+            .lines()
+            .any(|line| line == "?? managed/preexisting.txt")
+    );
+    assert!(
+        !status
+            .lines()
+            .any(|line| line.contains("managed/created.txt"))
+    );
+}
+
+#[test]
+fn project_setup_failure_is_reported() {
+    let result = Project::empty()
+        .setup_git()
+        .initial_commit("initial commit")
+        .build();
+
+    match result {
+        Err(Error::ProjectSetup { step, source }) => {
+            assert_eq!(step, "initial_commit");
+            let message = source.to_string();
+            assert!(message.starts_with("git ["));
+            assert!(
+                message.contains("git [\"add\", \"--\"]")
+                    || message.contains("git [\"commit\", \"-m\", \"initial commit\"]")
+            );
+        }
+        other => panic!("expected ProjectSetup error, got: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/scenario/tests/session_flow.rs
+++ b/crates/scenario/tests/session_flow.rs
@@ -1,0 +1,285 @@
+use std::sync::{Mutex, MutexGuard, OnceLock};
+use std::time::{Duration, Instant};
+
+use scenario::{Error, Key, Scenario, SessionConfig, Terminal};
+
+fn session_flow_guard() -> MutexGuard<'static, ()> {
+    static SESSION_FLOW_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    SESSION_FLOW_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap()
+}
+
+fn spawn(script: &str) -> scenario::Session {
+    Scenario::new("sh")
+        .args(["-c", script])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(5))
+        .spawn()
+        .unwrap()
+}
+
+#[test]
+fn session_config_applies_shared_terminal_and_timeout_settings() {
+    let _guard = session_flow_guard();
+    let config = SessionConfig::pty(72, 20).timeout(Duration::from_secs(1));
+
+    let mut session = Scenario::new("sh")
+        .args(["-c", "stty size; printf ready\\n; sleep 5"])
+        .session_config(&config)
+        .spawn()
+        .unwrap();
+
+    session.expect("20 72").unwrap();
+    session.expect("ready").unwrap();
+
+    let started = Instant::now();
+    let result = session.wait();
+
+    assert!(matches!(result, Err(Error::Timeout(_))));
+    assert!(started.elapsed() >= Duration::from_millis(900));
+    assert!(started.elapsed() < Duration::from_secs(3));
+}
+
+#[test]
+fn send_keys_submits_multiple_terminal_keys_in_order() {
+    let _guard = session_flow_guard();
+    let mut session =
+        spawn("stty raw -echo; printf 'ready\\n'; dd bs=1 count=7 status=none | od -An -tx1");
+
+    session.expect("ready").unwrap();
+    session
+        .send_keys([Key::Down, Key::Down, Key::Enter])
+        .unwrap();
+    session
+        .expect_regex(r"1b\s+5b\s+42.*1b\s+5b\s+42.*0d")
+        .unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn enter_and_ctrl_c_match_common_terminal_actions() {
+    let _guard = session_flow_guard();
+    let mut session = spawn(
+        "trap 'printf trapped\\n; exit 130' INT; printf ready\\n; IFS= read -r line; printf '%s' \"$line\" | od -An -tx1; while :; do sleep 1; done",
+    );
+
+    session.expect("ready").unwrap();
+    session.press(Key::Char('o')).unwrap();
+    session.press(Key::Char('k')).unwrap();
+    session.enter().unwrap();
+    session.expect_regex(r"6f\s+6b").unwrap();
+
+    session.ctrl_c().unwrap();
+    session.expect("trapped").unwrap();
+
+    let output = session.wait().unwrap();
+    assert_eq!(output.exit_code(), 130);
+}
+
+#[test]
+fn expect_screen_checks_visible_state_after_redraw() {
+    let _guard = session_flow_guard();
+    let mut session =
+        spawn(r#"printf 'Option A'; printf '\r\033[K'; printf '> Option B'; sleep 0.1"#);
+
+    session.expect("> Option B").unwrap();
+    session.expect_screen("> Option B").unwrap();
+    session.expect_screen_regex(r"> Option B").unwrap();
+    session.expect_screen_not("Option A").unwrap();
+    session.expect_screen_not_regex(r"Option A").unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_screen_not_monitors_through_the_quiet_period() {
+    let _guard = session_flow_guard();
+    let session =
+        spawn(r#"printf 'clean'; sleep 0.1; printf '\r\033[Kforbidden'; sleep 0.1; exit 0"#);
+
+    let result = session.expect_screen_not("forbidden");
+
+    assert!(matches!(result, Err(Error::UnexpectedPattern { .. })));
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_screen_not_timeout_uses_the_requested_quiet_period() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"printf 'clean'; sleep 0.08; exit 0"#);
+    let started = std::time::Instant::now();
+
+    session
+        .expect_screen_not_timeout("forbidden", Duration::from_millis(50))
+        .unwrap();
+
+    assert!(started.elapsed() < Duration::from_millis(200));
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_screen_not_regex_timeout_uses_the_requested_quiet_period() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"printf 'clean'; sleep 0.08; exit 0"#);
+    let started = std::time::Instant::now();
+
+    session
+        .expect_screen_not_regex_timeout(r"forbidden", Duration::from_millis(50))
+        .unwrap();
+
+    assert!(started.elapsed() < Duration::from_millis(200));
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_observes_settled_terminal_output() {
+    let _guard = session_flow_guard();
+    let mut session = spawn(r#"printf 'loading'; sleep 0.1; printf '\r\033[Kdone'; sleep 0.1"#);
+
+    session.expect("done").unwrap();
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+
+    assert_eq!(session.visible_text().lines().next().unwrap_or(""), "done");
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_succeeds_for_a_blank_stable_screen() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"printf 'temp'; printf '\r\033[K'; sleep 1"#);
+    let started = std::time::Instant::now();
+
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+
+    assert!(started.elapsed() >= Duration::from_millis(100));
+    assert!(session.visible_text().lines().all(|line| line.is_empty()));
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_succeeds_for_an_already_stable_running_screen() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"printf 'steady'; sleep 1"#);
+    let started = std::time::Instant::now();
+
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+
+    assert!(started.elapsed() >= Duration::from_millis(100));
+    assert!(started.elapsed() < Duration::from_millis(500));
+    assert_eq!(
+        session.visible_text().lines().next().unwrap_or(""),
+        "steady"
+    );
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_does_not_return_before_the_first_redraw() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"sleep 0.2; printf 'late'; sleep 0.05; exit 0"#);
+    let started = std::time::Instant::now();
+
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+
+    assert!(started.elapsed() >= Duration::from_millis(150));
+    assert_eq!(session.visible_text().lines().next().unwrap_or(""), "late");
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_waits_out_the_quiet_period_after_final_redraw_even_if_process_exits() {
+    let _guard = session_flow_guard();
+    let session = spawn(r#"sleep 0.05; printf 'done'; sleep 0.05; exit 0"#);
+    let started = std::time::Instant::now();
+
+    session
+        .wait_for_screen_stable(Duration::from_millis(200))
+        .unwrap();
+
+    assert!(started.elapsed() >= Duration::from_millis(240));
+    assert_eq!(session.visible_text().lines().next().unwrap_or(""), "done");
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn expect_screen_returns_immediately_after_process_exits_without_match() {
+    let _guard = session_flow_guard();
+    let session = spawn("printf 'ready\\n'; exit 0");
+    let started = std::time::Instant::now();
+
+    let result = session.expect_screen("never appears");
+
+    assert!(matches!(result, Err(Error::ExpectTimeout { .. })));
+    assert!(started.elapsed() < Duration::from_secs(1));
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn wait_for_screen_stable_times_out_when_screen_keeps_changing() {
+    let _guard = session_flow_guard();
+    let mut session = spawn(
+        r#"trap 'exit 0' INT; i=0; printf 'start\n'; while :; do printf '\rframe %s' "$i"; i=$((i + 1)); sleep 0.02; done"#,
+    );
+
+    let result = session.wait_for_screen_stable(Duration::from_millis(200));
+
+    assert!(matches!(result, Err(Error::Timeout(_))));
+
+    session.ctrl_c().unwrap();
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}
+
+#[test]
+fn screen_helpers_replace_current_output_slicing_for_redraw_flows() {
+    let _guard = session_flow_guard();
+    let mut session = spawn(
+        r#"printf 'What metric?\n> Runtime performance\n  Memory usage';
+           sleep 0.1;
+           printf '\033[2A\r\033[J';
+           printf 'How should we measure?\n> Benchmark runtime\n  Track memory';
+           sleep 0.1"#,
+    );
+
+    session.expect("How should we measure").unwrap();
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+    session.expect_screen("How should we measure").unwrap();
+    session.expect_screen_not("Runtime performance").unwrap();
+    session.expect_screen("Benchmark runtime").unwrap();
+
+    let output = session.wait().unwrap();
+    assert!(output.success());
+}

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -74,7 +74,7 @@ fn help_piped_no_ansi() {
 }
 
 #[test]
-fn help_pty_has_ansi() {
+fn help_pty_renders_in_terminal() {
     let output = ion()
         .args(["--help"])
         .terminal(Terminal::pty(80, 24))
@@ -82,11 +82,6 @@ fn help_pty_has_ansi() {
         .unwrap();
     assert!(output.success());
     assert!(output.stdout().contains("Agent skill manager"));
-    // Clap colors help output when it detects a real terminal
-    assert!(
-        output.stdout_raw().contains(&0x1B),
-        "PTY help output should contain ANSI color codes"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Improve the  crate for generic CLI dialog and workflow testing.

- add session input helpers: , , , 
- add visible-screen helpers and assertions: , , , 
- add reusable  for shared PTY and timeout settings
- add declarative  git setup helpers: , , 
- add autotune-style redraw regression coverage in new  integration tests
- correct a stale PTY help test assumption so the full repository suite reflects actual terminal behavior

## Verification

- 
- 
- 

## Notes

The unrelated local  modification and the spec/plan docs were intentionally left out of this PR.