### PR TITLE
fix: skip pre-install validation for binary skill sources

### DIFF
--- a/crates/ion-skill/src/installer.rs
+++ b/crates/ion-skill/src/installer.rs
@@ -92,6 +92,13 @@ impl<'a> SkillInstaller<'a> {
         _name: &str,
         source: &SkillSource,
     ) -> Result<validate::ValidationReport> {
+        // Binary sources don't have a SKILL.md to validate — the binary itself
+        // generates one at install time. They use a dedicated install pipeline
+        // (`install_binary`), so skip pre-install validation here.
+        if source.is_binary() {
+            return Ok(validate::ValidationReport::from_findings(Vec::new()));
+        }
+
         let skill_dir = self.fetch(source)?;
         let (meta, body) = self.validate_spec(&skill_dir, source)?;
         let report = validate::validate_skill_dir(&skill_dir, &meta, &body);


### PR DESCRIPTION
## Summary
- `ion add` (no args) / `ion install` failed when `Ion.toml` contained any binary skill (e.g. `armitage = { type = \"binary\", ... }`), erroring with `Source error: Binary source uses dedicated installer`.
- Root cause: `ValidationBuckets::collect` calls `installer.validate()` for every non-local skill, and `validate()` -> `fetch_skill_base()` deliberately returns that error for `SkillSourceKind::Binary`. The single-skill `ion add --bin <repo>` path worked because it skips validate() and dispatches straight to `install_binary`.
- Fix: short-circuit `validate()` for binary sources, returning an empty `ValidationReport`. They land in the `clean` bucket, and `install_approved_skills` -> `install_with_options` routes them to the existing `install_binary` pipeline.

## Repro
In an org with a binary skill in `Ion.toml`:
```
ion add
# Error: Source error: Binary source uses dedicated installer
```

## Test plan
- [x] `cargo build -p ion-skill` and full workspace build pass
- [x] Manually ran `ion add` in an org whose `Ion.toml` mixes a binary skill (`armitage`) with git/local skills — armitage installs alongside the others, no error
- [ ] Add a regression test covering `validate()` short-circuit for binary sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)