### PR TITLE
feat: add built-in TypeScript AGENTS.md template

### DIFF
--- a/crates/ion-skill/src/templates.rs
+++ b/crates/ion-skill/src/templates.rs
@@ -8,7 +8,7 @@
 pub const BUILTIN_PREFIX: &str = "builtin:";
 
 /// List of available built-in template names.
-pub const AVAILABLE: &[&str] = &["rust", "python", "julia", "rust+python"];
+pub const AVAILABLE: &[&str] = &["rust", "python", "julia", "typescript", "rust+python"];
 
 /// Return the embedded template content for a given name, or `None` if unknown.
 pub fn get(name: &str) -> Option<&'static str> {
@@ -16,6 +16,7 @@ pub fn get(name: &str) -> Option<&'static str> {
         "rust" => Some(include_str!("templates/rust.md")),
         "python" => Some(include_str!("templates/python.md")),
         "julia" => Some(include_str!("templates/julia.md")),
+        "typescript" | "ts" => Some(include_str!("templates/typescript.md")),
         "rust+python" | "rust-python" => Some(include_str!("templates/rust-python.md")),
         _ => None,
     }
@@ -45,6 +46,8 @@ mod tests {
         assert!(get("rust").is_some());
         assert!(get("python").is_some());
         assert!(get("julia").is_some());
+        assert!(get("typescript").is_some());
+        assert!(get("ts").is_some()); // alias
         assert!(get("rust+python").is_some());
         assert!(get("rust-python").is_some()); // alias
     }
@@ -60,6 +63,8 @@ mod tests {
         assert_eq!(parse_builtin_name("builtin:rust"), Some("rust"));
         assert_eq!(parse_builtin_name("builtin:python"), Some("python"));
         assert_eq!(parse_builtin_name("builtin:julia"), Some("julia"));
+        assert_eq!(parse_builtin_name("builtin:typescript"), Some("typescript"));
+        assert_eq!(parse_builtin_name("builtin:ts"), Some("ts"));
         assert_eq!(
             parse_builtin_name("builtin:rust+python"),
             Some("rust+python")

--- a/crates/ion-skill/src/templates/typescript.md
+++ b/crates/ion-skill/src/templates/typescript.md
@@ -1,0 +1,64 @@
+# AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project
+
+<!-- Describe your project here -->
+
+## Build & Test Commands
+
+```bash
+npm install                              # Install dependencies
+npm run build                            # Build (typically tsc or bundler)
+npm test                                 # All tests
+npm test -- --testNamePattern="name"     # Single test by name (Jest)
+npm run lint                             # Lint (ESLint)
+npm run format                           # Format (Prettier)
+npx tsc --noEmit                         # Type-check without emitting
+```
+
+If the project uses `pnpm` or `yarn`, substitute the package manager
+(`pnpm install`, `yarn install`, etc.). If it uses Bun, use `bun install`,
+`bun test`, `bun run build`.
+
+## Pre-commit Checklist
+
+**Run all four before committing:**
+
+```bash
+npm run format                                           # 1. Format
+npm run lint                                             # 2. Lint
+npx tsc --noEmit                                         # 3. Type-check
+npm test                                                 # 4. Test
+```
+
+## Project Structure
+
+- `package.json` -- project metadata, dependencies, and scripts
+- `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` -- locked versions (committed to git)
+- `tsconfig.json` -- TypeScript compiler configuration
+- `src/` -- source code (`.ts` / `.tsx`)
+- `tests/` or `__tests__/` -- test files (or `*.test.ts` co-located with source)
+- `dist/` or `build/` -- compiled output (gitignored)
+
+## Architecture
+
+<!-- Describe your architecture here. Examples: -->
+<!-- - Module organization and entry points (main, exports field) -->
+<!-- - Key types/interfaces and their relationships -->
+<!-- - Public API surface vs internal modules -->
+<!-- - Runtime targets (Node, browser, both) and bundler setup -->
+
+## Key Conventions
+
+- **TypeScript:** `strict` mode enabled in `tsconfig.json`; avoid `any` — prefer `unknown` and narrow with type guards
+- **Module system:** Prefer ES modules (`import`/`export`); set `"type": "module"` in `package.json` for Node
+- **Type definitions:** Co-locate types with implementation; expose public types from the package entry point
+- **Async:** Prefer `async`/`await` over raw Promise chains; handle rejections explicitly
+- **Imports:** Use absolute or path-aliased imports for cross-module references; relative imports within a module
+
+## Git Conventions
+
+- **Conventional commits:** `feat:`, `fix:`, `docs:`, `test:`, `ci:`, `refactor:`, `perf:`, `build:`, `chore:`
+- **Breaking changes:** Use `feat!:` or `fix!:` (note the `!`) or add a `BREAKING CHANGE:` footer

--- a/docs/src/content/docs/guides/workflows.mdx
+++ b/docs/src/content/docs/guides/workflows.mdx
@@ -28,7 +28,7 @@ $ ion init
 ✓ Updated Ion.toml with template source
 ```
 
-`ion init` detects your project language (Cargo.toml → rust, pyproject.toml → python, both → rust+python, Project.toml → julia) and offers to set up an `AGENTS.md` context file inline — no separate command needed.
+`ion init` detects your project language (Cargo.toml → rust, pyproject.toml → python, both → rust+python, Project.toml → julia, tsconfig.json → typescript) and offers to set up an `AGENTS.md` context file inline — no separate command needed.
 
 Commit the results:
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -114,11 +114,17 @@ fn detect_builtin_template(dir: &Path) -> Option<&'static str> {
         || dir.join("setup.py").exists()
         || dir.join("requirements.txt").exists();
     let has_julia = dir.join("Project.toml").exists();
-    match (has_cargo, has_python, has_julia) {
-        (true, true, _) => Some("rust+python"),
-        (true, false, _) => Some("rust"),
-        (false, true, _) => Some("python"),
-        (false, false, true) => Some("julia"),
+    let has_typescript = dir.join("tsconfig.json").exists()
+        || (dir.join("package.json").exists()
+            && (dir.join("tsconfig.json").exists()
+                || dir.join("src").join("index.ts").exists()
+                || dir.join("index.ts").exists()));
+    match (has_cargo, has_python, has_julia, has_typescript) {
+        (true, true, _, _) => Some("rust+python"),
+        (true, false, _, _) => Some("rust"),
+        (false, true, _, _) => Some("python"),
+        (false, false, true, _) => Some("julia"),
+        (false, false, false, true) => Some("typescript"),
         _ => None,
     }
 }
@@ -357,5 +363,30 @@ mod tests {
         let (name, path) = parse_target_flag("codex:custom/path").unwrap();
         assert_eq!(name, "codex");
         assert_eq!(path, "custom/path");
+    }
+
+    #[test]
+    fn detect_typescript_via_tsconfig() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        assert_eq!(detect_builtin_template(dir.path()), Some("typescript"));
+    }
+
+    #[test]
+    fn detect_typescript_via_index_ts() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::create_dir(dir.path().join("src")).unwrap();
+        std::fs::write(dir.path().join("src").join("index.ts"), "").unwrap();
+        assert_eq!(detect_builtin_template(dir.path()), Some("typescript"));
+    }
+
+    #[test]
+    fn detect_rust_takes_priority_over_typescript() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("Cargo.toml"), "").unwrap();
+        std::fs::write(dir.path().join("tsconfig.json"), "{}").unwrap();
+        assert_eq!(detect_builtin_template(dir.path()), Some("rust"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `builtin:typescript` template (with `builtin:ts` alias) — covers npm/pnpm/yarn/bun, `tsc --noEmit`, ESLint/Prettier, and strict-mode conventions
- Wires `ion init` auto-detection: `tsconfig.json` (or `package.json` + `src/index.ts`) → `typescript`; Rust/Python/Julia still take priority on mixed projects
- Updates the `ion init` workflow guide to mention `tsconfig.json` detection

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run -E 'test(templates::)'` — 6 passed (includes `templates_are_non_empty` which validates the new template has `# AGENTS.md`)
- [x] `cargo nextest run -E 'test(detect_typescript|detect_rust_takes)'` — 3 new detection tests pass
- [x] Manual: `ion agents init builtin:typescript` in a fresh TS project produces a usable AGENTS.md
- [x] Manual: `ion init` in a project with `tsconfig.json` suggests the `typescript` template

🤖 Generated with [Claude Code](https://claude.com/claude-code)