### PR TITLE
feat(scenario): add ScreenBuffer::occupied_rows() for flood assertions

### DIFF
--- a/crates/scenario/src/screen.rs
+++ b/crates/scenario/src/screen.rs
@@ -30,6 +30,17 @@ impl ScreenBuffer {
         parser.advance(self, raw_bytes);
     }
 
+    /// Number of screen rows that contain at least one non-space character.
+    ///
+    /// Useful for asserting that transient output (a status line, a progress
+    /// tail) stays bounded and doesn't flood the screen.
+    pub fn occupied_rows(&self) -> usize {
+        self.grid
+            .iter()
+            .filter(|row| row.iter().any(|&c| c != ' '))
+            .count()
+    }
+
     /// Return the current screen content, one `String` per row,
     /// with trailing spaces trimmed.
     pub fn lines(&self) -> Vec<String> {
@@ -326,5 +337,34 @@ mod tests {
         let lines = screen.lines();
         assert_eq!(lines[0], "ABCDE");
         assert_eq!(lines[1], "FGH");
+    }
+
+    #[test]
+    fn occupied_rows_counts_nonblank_rows() {
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"Line 1\r\nLine 2");
+        assert_eq!(screen.occupied_rows(), 2);
+    }
+
+    #[test]
+    fn occupied_rows_is_zero_for_blank_screen() {
+        let screen = ScreenBuffer::new(5, 20);
+        assert_eq!(screen.occupied_rows(), 0);
+    }
+
+    #[test]
+    fn occupied_rows_ignores_rows_cleared_by_erase() {
+        // Print three lines, then erase the whole display: nothing remains.
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"a\r\nb\r\nc\x1b[2J");
+        assert_eq!(screen.occupied_rows(), 0);
+    }
+
+    #[test]
+    fn occupied_rows_counts_only_rows_with_content() {
+        // Write to row 0 and row 3, leaving 1, 2, 4 blank.
+        let mut screen = ScreenBuffer::new(5, 20);
+        screen.process(b"top\x1b[4;1Hbottom");
+        assert_eq!(screen.occupied_rows(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Adds `ScreenBuffer::occupied_rows()` to the `scenario` crate: the number of screen rows containing at least one non-space character.

This is a reusable primitive for asserting that transient terminal output — a status line, a progress/log tail, an in-place spinner — stays **bounded** and doesn't flood the screen. Today callers hand-roll this with `visible_screen().iter().filter(|l| !l.is_empty()).count()` or `screen[N..].iter().all(|l| l.is_empty())`; `occupied_rows()` names the intent and lives next to the rest of the `ScreenBuffer` API.

Motivating use case: a downstream CLI ([autotune](https://github.com/Roger-luo/Ion)) renders a dimmed rolling "tail" of subprocess output via cursor-up + erase escape sequences. A regression there let the tail flood the screen when lines wrapped. `occupied_rows()` lets a PTY test assert the rendered screen never fills up — the kind of "no-flood" check the raw output stream can't express (only the vte-rendered screen reflects the erases).

## Changes

- `ScreenBuffer::occupied_rows(&self) -> usize` — counts rows with non-space content (post-vte, so cleared/erased rows don't count).
- 4 unit tests: non-blank rows, blank screen, rows cleared by `ESC[2J`, and sparse content (only rows with text counted).

## Test Plan

- [x] `cargo nextest run -p scenario` — full suite passes (incl. 4 new `occupied_rows` tests)
- [x] `cargo fmt -p scenario` clean
- [x] `cargo clippy -p scenario --all-targets -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)