### PR TITLE
chore(release): scenario v0.2.1

### DIFF
--- a/crates/scenario/CHANGELOG.md
+++ b/crates/scenario/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add ScreenBuffer::occupied_rows() for flood assertions ([#163](https://github.com/Roger-luo/Ion/pull/163)) (970ff4c)
 - Add expect_not() to assert text absence ([#126](https://github.com/Roger-luo/Ion/pull/126)) (1258498)
 - Add visible_screen() to get terminal display state ([#127](https://github.com/Roger-luo/Ion/pull/127)) (73aebf3)
 - Add send_key() helper for common terminal keys ([#125](https://github.com/Roger-luo/Ion/pull/125)) (c84d62d)

--- a/crates/scenario/Cargo.toml
+++ b/crates/scenario/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scenario"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Define and test CLI behavior scenarios — input/output, interactive sessions, and terminal conditions (TTY, dimensions, color)"
 license = "MIT"


### PR DESCRIPTION
Manual release of the `scenario` crate to publish `ScreenBuffer::occupied_rows()` (#163) to crates.io.

- Bumps `scenario` 0.2.0 → 0.2.1 (0.2.0 was tagged but never published; release-plz has scenario as `publish = false`, so scenario is released manually).
- Adds the changelog entry.

After merge: tag `scenario-v0.2.1` + `cargo publish -p scenario`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)