### PR TITLE
docs: regenerate API reference and add binary-skill CI guide

### DIFF
--- a/docs/src/content/docs/api-reference/ion-skill.md
+++ b/docs/src/content/docs/api-reference/ion-skill.md
@@ -6,27 +6,32 @@ order: 100
 
 *Version 0.1.0*
 
+Core library for Ion skill management — installation, validation, search, and configuration.
+
 ## Modules
 
 | Module | Description |
 |--------|-------------|
-| [agents](/docs/api-reference/ion-skill/agents) | AGENTS.md template management |
-| [binary](/docs/api-reference/ion-skill/binary) | Binary skill installation from GitHub Releases |
-| [config](/docs/api-reference/ion-skill/config) | Global user configuration |
-| [error](/docs/api-reference/ion-skill/error) | Error types |
-| [git](/docs/api-reference/ion-skill/git) | Git operations for skill management |
-| [gitignore](/docs/api-reference/ion-skill/gitignore) | Manage .gitignore entries for skills |
-| [installer](/docs/api-reference/ion-skill/installer) | Skill installation pipeline |
-| [lockfile](/docs/api-reference/ion-skill/lockfile) | Ion.lock types for pinned skill versions |
-| [manifest](/docs/api-reference/ion-skill/manifest) | Ion.toml project configuration types |
-| [manifest_writer](/docs/api-reference/ion-skill/manifest-writer) | Programmatic Ion.toml editing |
-| [migrate](/docs/api-reference/ion-skill/migrate) | Migrate skills from legacy formats |
-| [registry](/docs/api-reference/ion-skill/registry) | Global registry of skill repositories |
-| [search](/docs/api-reference/ion-skill/search) | Skill search results and multi-backend runners |
-| [skill](/docs/api-reference/ion-skill/skill) | SKILL.md parsing and metadata |
-| [source](/docs/api-reference/ion-skill/source) | Skill source abstraction |
-| [update](/docs/api-reference/ion-skill/update) | Check and apply skill updates |
-| [validate](/docs/api-reference/ion-skill/validate) | Skill validation framework |
+| [agents](/docs/api-reference/ion-skill/agents) | AGENTS.md template management — fetch, render, and keep agent context files up to date. |
+| [binary](/docs/api-reference/ion-skill/binary) | Binary skill installation — download from GitHub Releases, extract, and verify platform-specific executables. |
+| [config](/docs/api-reference/ion-skill/config) | Global user configuration — cache settings, registry sources, and agent target defaults stored in `~/.config/ion/config.toml`. |
+| [error](/docs/api-reference/ion-skill/error) | Error types for the ion-skill library, covering IO, parsing, Git, HTTP, validation, and manifest failures. |
+| [git](/docs/api-reference/ion-skill/git) | Git operations for skill management — clone, fetch, checkout, and compute directory checksums. |
+| [gitignore](/docs/api-reference/ion-skill/gitignore) | Manage `.gitignore` entries for installed skills and agent directories. |
+| [installer](/docs/api-reference/ion-skill/installer) | Skill installation pipeline — resolve, fetch, validate, deploy to target directories, and write manifest/lockfile. |
+| [lockfile](/docs/api-reference/ion-skill/lockfile) | Ion.lock types — track installed skills with pinned versions and checksums across Git, binary, and local sources. |
+| [manifest](/docs/api-reference/ion-skill/manifest) | Ion.toml types — project skill configuration with targets, skill entries, and per-project options. |
+| [manifest_writer](/docs/api-reference/ion-skill/manifest-writer) | Programmatic Ion.toml editing — add/remove skills, write targets, and set configuration options in place. |
+| [migrate](/docs/api-reference/ion-skill/migrate) | Migrate skills from legacy Ion formats to the current manifest and lockfile layout. |
+| [registry](/docs/api-reference/ion-skill/registry) | Global registry of skill repositories — tracks which projects use which remote repos and cleans up stale entries. |
+| [search](/docs/api-reference/ion-skill/search) | Skill search results and multi-backend search runners — GitHub, registry, and agent sources with relevance sorting. |
+| [skill](/docs/api-reference/ion-skill/skill) | SKILL.md parsing — read and validate skill metadata from frontmatter. |
+| [source](/docs/api-reference/ion-skill/source) | Skill source abstraction — represent and resolve GitHub, Git, HTTP, path, binary, and local skill origins. |
+| [templates](/docs/api-reference/ion-skill/templates) | Built-in AGENTS.md templates shipped with the ion binary. |
+| [tool_permission](/docs/api-reference/ion-skill/tool-permission) |  |
+| [update](/docs/api-reference/ion-skill/update) | Skill update infrastructure — check for newer versions and apply updates across Git and binary sources. |
+| [validate](/docs/api-reference/ion-skill/validate) | Skill validation framework — run checkers against SKILL.md files and aggregate findings by severity. |
+| [workspace](/docs/api-reference/ion-skill/workspace) | Project workspace context — load manifest and lockfile, resolve effective options and skill paths for a project. |
 
 ## Re-exports
 

--- a/docs/src/content/docs/api-reference/ion-skill/agents.md
+++ b/docs/src/content/docs/api-reference/ion-skill/agents.md
@@ -4,6 +4,8 @@ description: "AGENTS.md template management — fetch, render, and keep agent co
 order: 999
 ---
 
+AGENTS.md template management — fetch, render, and keep agent context files up to date.
+
 ## AgentsConfig
 
 Configuration for AGENTS.md template management.
@@ -107,6 +109,16 @@ Current UTC time as ISO 8601 string (e.g. "2026-03-27T12:00:00Z").
 
 ---
 
+## fetch_builtin_template
+
+```rust
+pub fn fetch_builtin_template(name: &str) -> Result<FetchedTemplate>
+```
+
+Return a `FetchedTemplate` from an embedded built-in template.
+
+---
+
 ## fetch_template
 
 ```rust
@@ -117,4 +129,6 @@ Fetch an AGENTS.md template from a source.
 
 Resolves the source using SkillSource::infer, fetches the repo/path,
 and extracts the AGENTS.md file at the specified path (default: root).
+Built-in templates (`builtin:rust`, etc.) are resolved from the binary
+without any network access.
 

--- a/docs/src/content/docs/api-reference/ion-skill/binary.md
+++ b/docs/src/content/docs/api-reference/ion-skill/binary.md
@@ -4,6 +4,8 @@ description: "Binary skill installation — download from GitHub Releases, extra
 order: 999
 ---
 
+Binary skill installation — download from GitHub Releases, extract, and verify platform-specific executables.
+
 ## BinaryValidation
 
 Result of validating an installed binary.
@@ -246,8 +248,9 @@ pub fn cargo_project_info(project_path: &Path) -> Result<CargoProject>
 
 Run `cargo metadata` to extract binary name and version from a Cargo project.
 
-Finds the first `[[bin]]` target in the package. Errors if no binary target is found
-or if the path doesn't contain a valid Cargo project.
+Finds the first `[[bin]]` target in the package. For workspaces, scans all member
+packages if the root package has no binary targets. Errors if no binary target is
+found or if the path doesn't contain a valid Cargo project.
 
 ---
 

--- a/docs/src/content/docs/api-reference/ion-skill/config.md
+++ b/docs/src/content/docs/api-reference/ion-skill/config.md
@@ -1,8 +1,10 @@
 ---
 title: "ion-skill::config"
-description: "Global user configuration — cache settings, registry sources, and agent target defaults stored in ~/.config/ion/config.toml."
+description: "Global user configuration — cache settings, registry sources, and agent target defaults stored in `~/.config/ion/config.toml`."
 order: 999
 ---
+
+Global user configuration — cache settings, registry sources, and agent target defaults stored in `~/.config/ion/config.toml`.
 
 ## GlobalConfig
 

--- a/docs/src/content/docs/api-reference/ion-skill/error.md
+++ b/docs/src/content/docs/api-reference/ion-skill/error.md
@@ -4,6 +4,8 @@ description: "Error types for the ion-skill library, covering IO, parsing, Git, 
 order: 999
 ---
 
+Error types for the ion-skill library, covering IO, parsing, Git, HTTP, validation, and manifest failures.
+
 ## Error
 
 ### Variants

--- a/docs/src/content/docs/api-reference/ion-skill/git.md
+++ b/docs/src/content/docs/api-reference/ion-skill/git.md
@@ -4,6 +4,8 @@ description: "Git operations for skill management — clone, fetch, checkout, an
 order: 999
 ---
 
+Git operations for skill management — clone, fetch, checkout, and compute directory checksums.
+
 ## clone_or_fetch
 
 ```rust

--- a/docs/src/content/docs/api-reference/ion-skill/gitignore.md
+++ b/docs/src/content/docs/api-reference/ion-skill/gitignore.md
@@ -1,8 +1,10 @@
 ---
 title: "ion-skill::gitignore"
-description: "Manage .gitignore entries for installed skills and agent directories."
+description: "Manage `.gitignore` entries for installed skills and agent directories."
 order: 999
 ---
+
+Manage `.gitignore` entries for installed skills and agent directories.
 
 ## find_missing_gitignore_entries
 

--- a/docs/src/content/docs/api-reference/ion-skill/installer.md
+++ b/docs/src/content/docs/api-reference/ion-skill/installer.md
@@ -4,6 +4,8 @@ description: "Skill installation pipeline — resolve, fetch, validate, deploy t
 order: 999
 ---
 
+Skill installation pipeline — resolve, fetch, validate, deploy to target directories, and write manifest/lockfile.
+
 ## SkillInstaller
 
 Manages skill installation and uninstallation for a project.
@@ -76,6 +78,15 @@ Used for multi-skill collection repos that have no root SKILL.md.
 ```rust
 pub fn uninstall(&self, name: &str) -> Result<()>
 ```
+
+#### `is_deployed`
+
+```rust
+pub fn is_deployed(&self, name: &str) -> bool
+```
+
+Check whether a skill is fully deployed: its canonical directory exists
+and all configured target symlinks are in place and resolve to valid paths.
 
 #### `deploy`
 

--- a/docs/src/content/docs/api-reference/ion-skill/lockfile.md
+++ b/docs/src/content/docs/api-reference/ion-skill/lockfile.md
@@ -4,6 +4,8 @@ description: "Ion.lock types — track installed skills with pinned versions and
 order: 999
 ---
 
+Ion.lock types — track installed skills with pinned versions and checksums across Git, binary, and local sources.
+
 ## LockedSkill
 
 ### Fields

--- a/docs/src/content/docs/api-reference/ion-skill/manifest-writer.md
+++ b/docs/src/content/docs/api-reference/ion-skill/manifest-writer.md
@@ -4,6 +4,8 @@ description: "Programmatic Ion.toml editing — add/remove skills, write targets
 order: 999
 ---
 
+Programmatic Ion.toml editing — add/remove skills, write targets, and set configuration options in place.
+
 ## add_skill
 
 ```rust
@@ -84,4 +86,25 @@ Delete a value from the [options] section of Ion.toml.
 
 For `targets.<key>`, removes the key from `[options.targets]`.
 For `options.<key>`, removes the key from `[options]`.
+
+---
+
+## add_workspace_member
+
+```rust
+pub fn add_workspace_member(manifest_path: &Path, member: &str) -> Result<String>
+```
+
+Add a member to [workspace].members in an Ion.toml file.
+Creates the [workspace] section if it doesn't exist.
+
+---
+
+## remove_workspace_member
+
+```rust
+pub fn remove_workspace_member(manifest_path: &Path, member: &str) -> Result<String>
+```
+
+Remove a member from [workspace].members in an Ion.toml file.
 

--- a/docs/src/content/docs/api-reference/ion-skill/manifest.md
+++ b/docs/src/content/docs/api-reference/ion-skill/manifest.md
@@ -4,6 +4,8 @@ description: "Ion.toml types — project skill configuration with targets, skill
 order: 999
 ---
 
+Ion.toml types — project skill configuration with targets, skill entries, and per-project options.
+
 ## ManifestOptions
 
 ### Fields
@@ -39,6 +41,26 @@ pub fn list_values(&self) -> Vec<(String, String)>
 ```
 
 List all project config values as (key, value) pairs.
+
+### Trait Implementations
+
+- `Debug`
+- `Clone`
+- `Default`
+- `Serialize`
+- `Deserialize<'de>`
+
+---
+
+## WorkspaceConfig
+
+Workspace configuration for multi-project setups.
+
+### Fields
+
+| Name | Type | Description |
+|------|------|-------------|
+| `members` | `Vec<String>` |  |
 
 ### Trait Implementations
 
@@ -92,6 +114,7 @@ Returns true if this project declares itself as a binary skill.
 | Name | Type | Description |
 |------|------|-------------|
 | `project` | `Option<ProjectMeta>` |  |
+| `workspace` | `Option<WorkspaceConfig>` |  |
 | `skills` | `BTreeMap<String, SkillEntry>` |  |
 | `options` | `ManifestOptions` |  |
 | `agents` | `Option<AgentsConfig>` |  |

--- a/docs/src/content/docs/api-reference/ion-skill/migrate.md
+++ b/docs/src/content/docs/api-reference/ion-skill/migrate.md
@@ -4,6 +4,8 @@ description: "Migrate skills from legacy Ion formats to the current manifest and
 order: 999
 ---
 
+Migrate skills from legacy Ion formats to the current manifest and lockfile layout.
+
 ## SkillsLockFile
 
 ### Fields

--- a/docs/src/content/docs/api-reference/ion-skill/registry.md
+++ b/docs/src/content/docs/api-reference/ion-skill/registry.md
@@ -4,6 +4,8 @@ description: "Global registry of skill repositories — tracks which projects us
 order: 999
 ---
 
+Global registry of skill repositories — tracks which projects use which remote repos and cleans up stale entries.
+
 ## RepoEntry
 
 ### Fields

--- a/docs/src/content/docs/api-reference/ion-skill/search.md
+++ b/docs/src/content/docs/api-reference/ion-skill/search.md
@@ -4,6 +4,8 @@ description: "Skill search results and multi-backend search runners — GitHub, 
 order: 999
 ---
 
+Skill search results and multi-backend search runners — GitHub, registry, and agent sources with relevance sorting.
+
 ## SearchResult
 
 Search result from any source.
@@ -16,7 +18,8 @@ Search result from any source.
 | `description` | `String` |  |
 | `source` | `String` |  |
 | `registry` | `String` |  |
-| `stars` | `Option<u64>` |  |
+| `stars` | `Option<u64>` | GitHub stargazer count. |
+| `weekly_installs` | `Option<u64>` | skills.sh weekly install count. |
 | `skill_description` | `Option<String>` |  |
 
 ### Methods
@@ -27,13 +30,22 @@ Search result from any source.
 pub fn new(name: impl Into<String>, description: impl Into<String>, source: impl Into<String>, registry: impl Into<String>) -> Self
 ```
 
-#### `sort_by_stars`
+#### `popularity`
 
 ```rust
-pub fn sort_by_stars(results: &mut [Self])
+pub fn popularity(&self) -> u64
 ```
 
-Sort results by stars descending (missing stars treated as 0).
+The popularity value used for ranking: weekly installs for skills.sh,
+stars for everything else.
+
+#### `sort_by_popularity`
+
+```rust
+pub fn sort_by_popularity(results: &mut [Self])
+```
+
+Sort results by popularity descending.
 
 #### `sort_by_relevance`
 
@@ -42,8 +54,9 @@ pub fn sort_by_relevance(results: &mut [Self], query: &str)
 ```
 
 Sort results by relevance to the query, combining text match quality
-with popularity (stars). Exact name/source matches rank highest,
-then prefix matches, then substring matches, with stars as tiebreaker.
+with normalized popularity. Popularity (stars / installs) is normalized
+per-registry so that different scales (GitHub stars vs skills.sh weekly
+installs) become comparable.
 
 ### Trait Implementations
 

--- a/docs/src/content/docs/api-reference/ion-skill/skill.md
+++ b/docs/src/content/docs/api-reference/ion-skill/skill.md
@@ -4,6 +4,8 @@ description: "SKILL.md parsing — read and validate skill metadata from frontma
 order: 999
 ---
 
+SKILL.md parsing — read and validate skill metadata from frontmatter.
+
 ## SkillMetadata
 
 Parsed SKILL.md frontmatter.

--- a/docs/src/content/docs/api-reference/ion-skill/source.md
+++ b/docs/src/content/docs/api-reference/ion-skill/source.md
@@ -4,6 +4,8 @@ description: "Skill source abstraction — represent and resolve GitHub, Git, HT
 order: 999
 ---
 
+Skill source abstraction — represent and resolve GitHub, Git, HTTP, path, binary, and local skill origins.
+
 ## SkillSource
 
 A fully resolved skill source.

--- a/docs/src/content/docs/api-reference/ion-skill/templates.md
+++ b/docs/src/content/docs/api-reference/ion-skill/templates.md
@@ -1,0 +1,35 @@
+---
+title: "ion-skill::templates"
+description: "Built-in AGENTS.md templates shipped with the ion binary."
+order: 999
+---
+
+Built-in AGENTS.md templates shipped with the ion binary.
+
+These templates provide offline project scaffolding for common language
+ecosystems. When ion is updated, the embedded templates update too —
+`ion agents update` will detect the new content via checksum comparison.
+
+## get
+
+```rust
+pub fn get(name: &str) -> Option<&'static str>
+```
+
+Return the embedded template content for a given name, or `None` if unknown.
+
+---
+
+## parse_builtin_name
+
+```rust
+pub fn parse_builtin_name(source: &str) -> Option<&str>
+```
+
+Parse a source string into a built-in template name if it matches.
+
+Only the `builtin:` prefix is recognized (e.g. `builtin:rust`).
+Bare names like `rust` are treated as remote sources to avoid
+ambiguity with source aliases.
+Returns `None` if the source doesn't refer to a known built-in template.
+

--- a/docs/src/content/docs/api-reference/ion-skill/tool-permission.md
+++ b/docs/src/content/docs/api-reference/ion-skill/tool-permission.md
@@ -1,0 +1,105 @@
+---
+title: "ion-skill::tool_permission"
+description: ""
+order: 999
+---
+
+## ToolRequest
+
+A tool request parsed from a `<request-tool>` element in a skill body.
+
+A request may optionally include a `<scope>` to narrow the permission.
+For example:
+
+```xml
+<request-tool>
+  <tool>Bash</tool>
+  <scope>cargo tree:*</scope>
+</request-tool>
+```
+
+### Fields
+
+| Name | Type | Description |
+|------|------|-------------|
+| `tool` | `String` | The tool name, e.g. `"Bash"`. |
+| `scope` | `Option<String>` | An optional scope pattern that narrows the request, e.g. `"cargo tree:*"`. |
+
+### Methods
+
+#### `new`
+
+```rust
+pub fn new(tool: impl Into<String>) -> Self
+```
+
+Create a new unscoped tool request.
+
+#### `scoped`
+
+```rust
+pub fn scoped(tool: impl Into<String>, scope: impl Into<String>) -> Self
+```
+
+Create a new scoped tool request.
+
+#### `approval_label`
+
+```rust
+pub fn approval_label(&self) -> String
+```
+
+The label shown in the approval prompt.
+
+Scoped requests display as `Tool(scope)` (e.g. `Bash(cargo tree:*)`);
+unscoped requests display the bare tool name (e.g. `Bash`).
+
+#### `grant`
+
+```rust
+pub fn grant(&self) -> ToolPermission
+```
+
+Produce the [`ToolPermission`] that should be recorded in the session
+when the user approves this request.
+
+### Trait Implementations
+
+- `Debug`
+- `Clone`
+- `PartialEq`
+- `Eq`
+- `Display`
+
+---
+
+## ToolPermission
+
+A permission granted to a session for a specific tool.
+
+### Variants
+
+- **`Allow(String)`** — Unrestricted access to the named tool.
+- **`AllowScoped { tool: String, scope: String }`** — Access to the named tool, restricted to commands matching the scope pattern.
+
+### Trait Implementations
+
+- `Debug`
+- `Clone`
+- `PartialEq`
+- `Eq`
+- `Display`
+
+---
+
+## parse_tool_requests
+
+```rust
+pub fn parse_tool_requests(body: &str) -> Vec<ToolRequest>
+```
+
+Parse all `<request-tool>` elements from a skill body.
+
+Each element must contain a `<tool>` child; an optional `<scope>` child
+narrows the request.  Returns an empty vec when no elements are found.
+

--- a/docs/src/content/docs/api-reference/ion-skill/update.md
+++ b/docs/src/content/docs/api-reference/ion-skill/update.md
@@ -4,6 +4,8 @@ description: "Skill update infrastructure — check for newer versions and apply
 order: 999
 ---
 
+Skill update infrastructure — check for newer versions and apply updates across Git and binary sources.
+
 ## UpdateInfo
 
 Information about an available update.

--- a/docs/src/content/docs/api-reference/ion-skill/update/binary.md
+++ b/docs/src/content/docs/api-reference/ion-skill/update/binary.md
@@ -4,6 +4,8 @@ description: "Updater for binary skills — check and download newer releases fr
 order: 999
 ---
 
+Updater for binary skills — check and download newer releases from GitHub.
+
 ## BinaryUpdater
 
 Updater for binary skills installed from GitHub Releases.

--- a/docs/src/content/docs/api-reference/ion-skill/update/git.md
+++ b/docs/src/content/docs/api-reference/ion-skill/update/git.md
@@ -4,6 +4,8 @@ description: "Updater for Git-sourced skills — fetch the latest commit from th
 order: 999
 ---
 
+Updater for Git-sourced skills — fetch the latest commit from the default branch and redeploy.
+
 ## GitUpdater
 
 Updater for Git and GitHub-sourced skills.

--- a/docs/src/content/docs/api-reference/ion-skill/validate.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate.md
@@ -4,6 +4,8 @@ description: "Skill validation framework — run checkers against SKILL.md files
 order: 999
 ---
 
+Skill validation framework — run checkers against SKILL.md files and aggregate findings by severity.
+
 ## Finding
 
 A single validation finding produced by a checker.

--- a/docs/src/content/docs/api-reference/ion-skill/validate/codeblock.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate/codeblock.md
@@ -4,5 +4,7 @@ description: "Validate syntax of fenced code blocks in SKILL.md files using tree
 order: 999
 ---
 
+Validate syntax of fenced code blocks in SKILL.md files using tree-sitter.
+
 ## TreeSitterCodeBlockChecker
 

--- a/docs/src/content/docs/api-reference/ion-skill/validate/discovery.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate/discovery.md
@@ -4,6 +4,8 @@ description: "Discover SKILL.md files recursively within a project directory."
 order: 999
 ---
 
+Discover SKILL.md files recursively within a project directory.
+
 ## discover_skill_files
 
 ```rust

--- a/docs/src/content/docs/api-reference/ion-skill/validate/markdown.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate/markdown.md
@@ -4,6 +4,8 @@ description: "Markdown parsing utilities — extract code blocks, local links, a
 order: 999
 ---
 
+Markdown parsing utilities — extract code blocks, local links, and tool mentions from SKILL.md content.
+
 ## CodeBlock
 
 ### Fields

--- a/docs/src/content/docs/api-reference/ion-skill/validate/security.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate/security.md
@@ -4,6 +4,8 @@ description: "Security checkers for SKILL.md — detect prompt injection pattern
 order: 999
 ---
 
+Security checkers for SKILL.md — detect prompt injection patterns, dangerous commands, and suspicious file references.
+
 ## PromptInjectionChecker
 
 ---

--- a/docs/src/content/docs/api-reference/ion-skill/validate/structure.md
+++ b/docs/src/content/docs/api-reference/ion-skill/validate/structure.md
@@ -4,6 +4,8 @@ description: "Structural checkers for SKILL.md — verify reference integrity an
 order: 999
 ---
 
+Structural checkers for SKILL.md — verify reference integrity and tool declaration consistency.
+
 ## ReferenceIntegrityChecker
 
 ---

--- a/docs/src/content/docs/api-reference/ion-skill/workspace.md
+++ b/docs/src/content/docs/api-reference/ion-skill/workspace.md
@@ -4,6 +4,8 @@ description: "Project workspace context — load manifest and lockfile, resolve 
 order: 999
 ---
 
+Project workspace context — load manifest and lockfile, resolve effective options and skill paths for a project.
+
 ## Project
 
 A single project within a workspace (or the root project itself).

--- a/docs/src/content/docs/api-reference/ionem.md
+++ b/docs/src/content/docs/api-reference/ionem.md
@@ -4,7 +4,7 @@ description: "Library for building Ion binary skills."
 order: 100
 ---
 
-*Version 0.2.0*
+*Version 0.2.1*
 
 Library for building Ion binary skills.
 
@@ -45,10 +45,10 @@ See [`build`] for SKILL.md preparation and [`self_update::SelfManager`] for the 
 | Module | Description |
 |--------|-------------|
 | [build](/docs/api-reference/ionem/build) | Build-script helpers for binary skills. |
-| [error](/docs/api-reference/ionem/error) | Error types for binary skill operations. |
+| [error](/docs/api-reference/ionem/error) |  |
 | [release](/docs/api-reference/ionem/release) | GitHub release fetching and platform detection for binary skills. |
 | [self_update](/docs/api-reference/ionem/self-update) | Reusable self-management infrastructure for binary skills. |
-| [shell](/docs/api-reference/ionem/shell) | CLI tool descriptors and wrappers for git, cargo, and gh. |
+| [shell](/docs/api-reference/ionem/shell) |  |
 
 ## Re-exports
 

--- a/docs/src/content/docs/api-reference/ionem/error.md
+++ b/docs/src/content/docs/api-reference/ionem/error.md
@@ -1,6 +1,6 @@
 ---
 title: "ionem::error"
-description: "Error types for the ionem library — IO, HTTP, and general errors from binary skill operations."
+description: ""
 order: 999
 ---
 

--- a/docs/src/content/docs/api-reference/ionem/shell.md
+++ b/docs/src/content/docs/api-reference/ionem/shell.md
@@ -1,6 +1,6 @@
 ---
 title: "ionem::shell"
-description: "CLI tool descriptors and error types for shell command wrappers (git, cargo, gh)."
+description: ""
 order: 999
 ---
 

--- a/docs/src/content/docs/api-reference/ionem/shell/cargo.md
+++ b/docs/src/content/docs/api-reference/ionem/shell/cargo.md
@@ -124,6 +124,17 @@ Verify `cargo` is installed and return a handle to run commands.
 
 ---
 
+## raw_metadata
+
+```rust
+pub fn raw_metadata(manifest_path: &Path) -> Result<String>
+```
+
+Run `cargo metadata --no-deps` and return the raw JSON string.
+Useful when callers need to inspect all workspace packages directly.
+
+---
+
 ## metadata
 
 ```rust

--- a/docs/src/content/docs/api-reference/scenario.md
+++ b/docs/src/content/docs/api-reference/scenario.md
@@ -4,7 +4,7 @@ description: "Define and test CLI behavior scenarios under controlled terminal c
 order: 100
 ---
 
-*Version 0.1.1*
+*Version 0.2.0*
 
 # scenario
 
@@ -49,14 +49,18 @@ let output = session.wait().unwrap();
 | Module | Description |
 |--------|-------------|
 | [manifest](/docs/api-reference/scenario/manifest) | Parsing for `template.toml` manifest files. |
+| [screen](/docs/api-reference/scenario/screen) |  |
 
 ## Re-exports
 
 - `pub use error::Error` as **Error**
+- `pub use key::Key` as **Key**
 - `pub use output::Output` as **Output**
 - `pub use project::Project` as **Project**
 - `pub use project::ProjectBuilder` as **ProjectBuilder**
 - `pub use scenario::Scenario` as **Scenario**
+- `pub use scenario::SessionConfig` as **SessionConfig**
 - `pub use scenario::Terminal` as **Terminal**
+- `pub use screen::ScreenBuffer` as **ScreenBuffer**
 - `pub use session::Session` as **Session**
 

--- a/docs/src/content/docs/api-reference/scenario/screen.md
+++ b/docs/src/content/docs/api-reference/scenario/screen.md
@@ -1,0 +1,42 @@
+---
+title: "scenario::screen"
+description: ""
+order: 999
+---
+
+## ScreenBuffer
+
+A virtual terminal screen buffer that interprets ANSI escape sequences.
+
+Maintains a grid of characters representing what would be visible on
+a terminal of the given dimensions after processing raw PTY output.
+
+*…and private fields*
+
+### Methods
+
+#### `new`
+
+```rust
+pub fn new(rows: usize, cols: usize) -> Self
+```
+
+Create a new empty screen buffer with the given dimensions.
+
+#### `process`
+
+```rust
+pub fn process(&mut self, raw_bytes: &[u8])
+```
+
+Feed raw PTY output through the VT parser, updating the grid.
+
+#### `lines`
+
+```rust
+pub fn lines(&self) -> Vec<String>
+```
+
+Return the current screen content, one `String` per row,
+with trailing spaces trimmed.
+

--- a/docs/src/content/docs/guides/binary-skills.mdx
+++ b/docs/src/content/docs/guides/binary-skills.mdx
@@ -156,6 +156,39 @@ $ ion add owner/my-linter --bin
   </Fragment>
 </WorkflowTabs>
 
+## Setting up CI
+
+`ion init --bin` prompts to set up CI during scaffolding. For an existing Cargo project, run it directly from the project root:
+
+```bash
+ion ci
+```
+
+This reads the package name from `Cargo.toml` and writes four files:
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/ci.yml` | Format check, Clippy lint, tests on Ubuntu and macOS |
+| `.github/workflows/release.yml` | Builds release binaries for 4 targets on tag push |
+| `.github/workflows/release-plz.yml` | Opens version-bump PRs on every push to `main` |
+| `release-plz.toml` | Changelog format and `publish = false` (binaries ship via GitHub Releases, not crates.io) |
+
+If any of these files already exist, `ion ci` errors. Use `--force` to overwrite:
+
+```bash
+ion ci --force
+```
+
+### What the release flow looks like
+
+Once CI is in place, the release loop is:
+
+1. Merge commits to `main` — `release-plz` opens a version-bump PR with a generated changelog
+2. Merge the version-bump PR — `release-plz` creates a tag (e.g. `v1.2.0`)
+3. The tag triggers `release.yml`, which builds binaries for all four targets and attaches them to the GitHub Release
+
+Users then install the published binary with `ion add owner/my-linter`.
+
 ## Publishing a release
 
 <WorkflowTabs prompt="Help me publish a new release of this binary skill. Tag the version, verify the release workflow builds binaries for all targets, and confirm the asset naming follows the ion convention.">

--- a/docs/src/data/api-navigation.json
+++ b/docs/src/data/api-navigation.json
@@ -67,6 +67,14 @@
         "slug": "api-reference/ion-skill/source"
       },
       {
+        "title": "templates",
+        "slug": "api-reference/ion-skill/templates"
+      },
+      {
+        "title": "tool_permission",
+        "slug": "api-reference/ion-skill/tool-permission"
+      },
+      {
         "title": "update",
         "slug": "api-reference/ion-skill/update"
       },
@@ -101,6 +109,10 @@
       {
         "title": "validate::structure",
         "slug": "api-reference/ion-skill/validate/structure"
+      },
+      {
+        "title": "workspace",
+        "slug": "api-reference/ion-skill/workspace"
       }
     ]
   },
@@ -155,6 +167,10 @@
       {
         "title": "manifest",
         "slug": "api-reference/scenario/manifest"
+      },
+      {
+        "title": "screen",
+        "slug": "api-reference/scenario/screen"
       }
     ]
   }

--- a/docs/superpowers/plans/2026-04-13-scenario-cli-flow-testing.md
+++ b/docs/superpowers/plans/2026-04-13-scenario-cli-flow-testing.md
@@ -1,0 +1,641 @@
+# Scenario CLI Flow Testing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add generic `scenario` crate APIs that make interactive CLI flow tests shorter, less flaky, and more screen-oriented, using the `autotune2` test suite as the reference workload.
+
+**Architecture:** Extend the existing `Session` and `ProjectBuilder` types instead of introducing a new DSL. Build new helpers on top of the current PTY/session primitives so existing tests keep working, while new tests can express user actions, visible-screen assertions, and repo-backed fixtures more directly.
+
+**Tech Stack:** Rust 2024, `scenario` crate, `portable-pty`, `regex`, `tempfile`, shell `git`, crate integration tests under `crates/scenario/tests/`
+
+---
+
+## File Structure
+
+- Modify: `crates/scenario/src/error.rs`
+  Add one post-build setup error variant for `ProjectBuilder` git actions and reuse existing timeout-style errors where possible.
+- Modify: `crates/scenario/src/project.rs`
+  Add generic project setup actions (`setup_git`, `git_user`, `initial_commit`) and run them after materializing files.
+- Modify: `crates/scenario/src/session.rs`
+  Add input ergonomics (`send_keys`, `press`, `enter`, `ctrl_c`), visible-screen string helpers, screen expectations, and a screen stabilization helper.
+- Modify: `crates/scenario/src/lib.rs`
+  Export any new public helper types if needed, especially `SessionConfig`.
+- Modify: `crates/scenario/src/scenario.rs`
+  Add a small reusable `SessionConfig` profile type and `Scenario::session_config`.
+- Test: `crates/scenario/tests/project.rs`
+  Extend project tests for repo-backed setup actions and failure cases.
+- Create: `crates/scenario/tests/session_flow.rs`
+  Add public API integration tests for input ergonomics, screen assertions, and stable-screen waiting.
+- Reference only: `../autotune2/crates/autotune/tests/scenario_init_test.rs`
+  Use as the migration target when choosing API names and examples, but do not modify it in this plan.
+
+---
+
+### Task 1: Add Session Input Ergonomics
+
+**Files:**
+- Modify: `crates/scenario/src/session.rs`
+- Test: `crates/scenario/tests/session_flow.rs`
+
+- [ ] **Step 1: Write the failing integration tests for generic input helpers**
+
+Add these tests to `crates/scenario/tests/session_flow.rs`:
+
+```rust
+use std::time::Duration;
+
+use scenario::{Key, Scenario, Terminal};
+
+fn spawn(script: &str) -> scenario::Session {
+    Scenario::new("sh")
+        .args(["-c", script])
+        .terminal(Terminal::pty(80, 24))
+        .timeout(Duration::from_secs(5))
+        .spawn()
+        .unwrap()
+}
+
+#[test]
+fn send_keys_submits_multiple_terminal_keys_in_order() {
+    let mut session = spawn(
+        "printf 'ready\\n'; IFS= read -r line; printf '%s' \"$line\" | od -An -tx1",
+    );
+
+    session.expect("ready").unwrap();
+    session
+        .send_keys([Key::Down, Key::Down, Key::Enter])
+        .unwrap();
+    session.expect_regex(r\"1b\\s+5b\\s+42.*1b\\s+5b\\s+42.*0d\").unwrap();
+}
+
+#[test]
+fn enter_and_ctrl_c_match_common_terminal_actions() {
+    let mut session = spawn(
+        \"trap 'printf trapped\\\\n; exit 130' INT; printf ready\\\\n; while :; do sleep 1; done\",
+    );
+
+    session.expect(\"ready\").unwrap();
+    session.ctrl_c().unwrap();
+    session.expect(\"trapped\").unwrap();
+
+    let output = session.wait().unwrap();
+    assert_eq!(output.exit_code(), 130);
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow send_keys_submits_multiple_terminal_keys_in_order -- --nocapture
+```
+
+Expected: FAIL because `Session` does not yet implement `send_keys`, `enter`, or `ctrl_c`.
+
+- [ ] **Step 3: Implement the minimal session input helpers**
+
+Update `crates/scenario/src/session.rs` by adding these methods near the existing `send_key()` implementation:
+
+```rust
+    pub fn send_keys<I>(&mut self, keys: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = Key>,
+    {
+        for key in keys {
+            self.send_key(key)?;
+        }
+        Ok(())
+    }
+
+    pub fn press(&mut self, key: Key) -> Result<(), Error> {
+        self.send_key(key)
+    }
+
+    pub fn enter(&mut self) -> Result<(), Error> {
+        self.send_key(Key::Enter)
+    }
+
+    pub fn ctrl_c(&mut self) -> Result<(), Error> {
+        self.send_key(Key::CtrlC)
+    }
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow
+```
+
+Expected: PASS for the new input-helper tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenario/src/session.rs crates/scenario/tests/session_flow.rs
+git commit -m "feat(scenario): add session input helper methods"
+```
+
+---
+
+### Task 2: Add Visible-Screen Assertions and Stabilization
+
+**Files:**
+- Modify: `crates/scenario/src/session.rs`
+- Test: `crates/scenario/tests/session_flow.rs`
+
+- [ ] **Step 1: Write the failing integration tests for screen assertions**
+
+Append these tests to `crates/scenario/tests/session_flow.rs`:
+
+```rust
+#[test]
+fn expect_screen_checks_visible_state_after_redraw() {
+    let mut session = spawn(
+        r#"printf 'Option A'; printf '\r\033[K'; printf '> Option B'; sleep 0.1"#,
+    );
+
+    session.expect("> Option B").unwrap();
+    session.expect_screen("> Option B").unwrap();
+    session.expect_screen_not("Option A").unwrap();
+}
+
+#[test]
+fn wait_for_screen_stable_observes_settled_terminal_output() {
+    let mut session = spawn(
+        r#"printf 'loading'; sleep 0.1; printf '\r\033[Kdone'; sleep 0.1"#,
+    );
+
+    session.expect("done").unwrap();
+    session
+        .wait_for_screen_stable(Duration::from_millis(100))
+        .unwrap();
+
+    assert_eq!(session.visible_text().lines().next().unwrap_or(""), "done");
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow expect_screen_checks_visible_state_after_redraw -- --nocapture
+```
+
+Expected: FAIL because `expect_screen`, `expect_screen_not`, `visible_text`, and `wait_for_screen_stable` do not exist yet.
+
+- [ ] **Step 3: Implement minimal visible-screen APIs**
+
+In `crates/scenario/src/session.rs`, add:
+
+```rust
+    pub fn visible_text(&self) -> String {
+        self.visible_screen().join("\n")
+    }
+
+    pub fn expect_screen(&self, pattern: &str) -> Result<(), Error> {
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            if self.visible_text().contains(pattern) {
+                return Ok(());
+            }
+            if self.is_done() || Instant::now() >= deadline {
+                return Err(Error::ExpectTimeout {
+                    pattern: pattern.to_string(),
+                    timeout: self.timeout,
+                    buffer: self.visible_text(),
+                });
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    pub fn expect_screen_regex(&self, pattern: &str) -> Result<(), Error> {
+        let re = Regex::new(pattern)?;
+        let deadline = Instant::now() + self.timeout;
+        loop {
+            let visible = self.visible_text();
+            if re.is_match(&visible) {
+                return Ok(());
+            }
+            if self.is_done() || Instant::now() >= deadline {
+                return Err(Error::ExpectTimeout {
+                    pattern: pattern.to_string(),
+                    timeout: self.timeout,
+                    buffer: visible,
+                });
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    pub fn expect_screen_not(&self, pattern: &str) -> Result<(), Error> {
+        self.wait_for_screen_stable(Duration::from_millis(100))?;
+        let visible = self.visible_text();
+        if visible.contains(pattern) {
+            return Err(Error::UnexpectedPattern {
+                pattern: pattern.to_string(),
+                buffer: visible,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn expect_screen_not_regex(&self, pattern: &str) -> Result<(), Error> {
+        self.wait_for_screen_stable(Duration::from_millis(100))?;
+        let re = Regex::new(pattern)?;
+        let visible = self.visible_text();
+        if re.is_match(&visible) {
+            return Err(Error::UnexpectedPattern {
+                pattern: pattern.to_string(),
+                buffer: visible,
+            });
+        }
+        Ok(())
+    }
+
+    pub fn wait_for_screen_stable(&self, quiet_period: Duration) -> Result<(), Error> {
+        let deadline = Instant::now() + self.timeout;
+        let mut last = self.visible_text();
+        let mut stable_since = Instant::now();
+
+        loop {
+            thread::sleep(Duration::from_millis(10));
+            let current = self.visible_text();
+            if current == last {
+                if stable_since.elapsed() >= quiet_period {
+                    return Ok(());
+                }
+            } else {
+                last = current;
+                stable_since = Instant::now();
+            }
+
+            if self.is_done() && self.visible_text() == last && stable_since.elapsed() >= quiet_period {
+                return Ok(());
+            }
+
+            if Instant::now() >= deadline {
+                return Err(Error::ExpectTimeout {
+                    pattern: format!("stable screen for {:?}", quiet_period),
+                    timeout: self.timeout,
+                    buffer: self.visible_text(),
+                });
+            }
+        }
+    }
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow
+```
+
+Expected: PASS for both the input-helper tests and the new visible-screen tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenario/src/session.rs crates/scenario/tests/session_flow.rs
+git commit -m "feat(scenario): add screen-based session assertions"
+```
+
+---
+
+### Task 3: Add Reusable Session Profiles
+
+**Files:**
+- Modify: `crates/scenario/src/scenario.rs`
+- Modify: `crates/scenario/src/lib.rs`
+- Test: `crates/scenario/tests/session_flow.rs`
+
+- [ ] **Step 1: Write the failing test for reusable session config**
+
+Append this test to `crates/scenario/tests/session_flow.rs`:
+
+```rust
+use scenario::{SessionConfig, Terminal};
+
+#[test]
+fn session_config_applies_shared_terminal_and_timeout_settings() {
+    let config = SessionConfig::pty(90, 20).timeout(Duration::from_secs(3));
+
+    let session = Scenario::new("cat")
+        .session_config(&config)
+        .spawn()
+        .unwrap();
+
+    assert_eq!(session.pty_size(), (20, 90));
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow session_config_applies_shared_terminal_and_timeout_settings -- --nocapture
+```
+
+Expected: FAIL because `SessionConfig` and `Scenario::session_config` do not exist.
+
+- [ ] **Step 3: Implement the reusable session profile type**
+
+In `crates/scenario/src/scenario.rs`, add:
+
+```rust
+pub struct SessionConfig {
+    terminal: Terminal,
+    timeout: Duration,
+}
+
+impl SessionConfig {
+    pub fn pty(cols: u16, rows: u16) -> Self {
+        Self {
+            terminal: Terminal::pty(cols, rows),
+            timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+```
+
+And add:
+
+```rust
+    pub fn session_config(mut self, config: &SessionConfig) -> Self {
+        self.terminal = config.terminal.clone();
+        self.timeout = config.timeout;
+        self
+    }
+```
+
+Export `SessionConfig` from `crates/scenario/src/lib.rs`:
+
+```rust
+pub use scenario::{Scenario, SessionConfig, Terminal};
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p scenario --test session_flow
+```
+
+Expected: PASS including the new shared-config test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenario/src/scenario.rs crates/scenario/src/lib.rs crates/scenario/tests/session_flow.rs
+git commit -m "feat(scenario): add reusable session configuration"
+```
+
+---
+
+### Task 4: Add Generic Git Setup Actions to ProjectBuilder
+
+**Files:**
+- Modify: `crates/scenario/src/error.rs`
+- Modify: `crates/scenario/src/project.rs`
+- Test: `crates/scenario/tests/project.rs`
+
+- [ ] **Step 1: Write the failing tests for repo-backed project setup**
+
+Add these tests to `crates/scenario/tests/project.rs`:
+
+```rust
+#[test]
+fn project_setup_git_initializes_a_repository() {
+    let project = Project::empty().file("README.md", "hello\n").setup_git().build().unwrap();
+
+    assert!(project.path().join(".git").exists());
+}
+
+#[test]
+fn project_initial_commit_creates_head_commit() {
+    let project = Project::empty()
+        .file("README.md", "hello\n")
+        .setup_git()
+        .git_user("Test", "test@example.com")
+        .initial_commit("initial")
+        .build()
+        .unwrap();
+
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(project.path())
+        .output()
+        .unwrap();
+
+    assert!(output.status.success(), "git rev-parse HEAD should succeed");
+}
+```
+
+- [ ] **Step 2: Run the targeted test to verify it fails**
+
+Run:
+
+```bash
+cargo test -p scenario --test project project_initial_commit_creates_head_commit -- --nocapture
+```
+
+Expected: FAIL because `ProjectBuilder` does not yet implement `setup_git`, `git_user`, or `initial_commit`.
+
+- [ ] **Step 3: Implement post-build project setup actions**
+
+Add a new error variant to `crates/scenario/src/error.rs`:
+
+```rust
+    #[error("project setup step {step} failed: {source}")]
+    ProjectSetup {
+        step: String,
+        source: std::io::Error,
+    },
+```
+
+In `crates/scenario/src/project.rs`, extend `ProjectBuilder` with fields to track setup requests and add methods:
+
+```rust
+    pub fn setup_git(mut self) -> Self {
+        self.setup_git = true;
+        self
+    }
+
+    pub fn git_user(mut self, name: &str, email: &str) -> Self {
+        self.git_user = Some((name.to_string(), email.to_string()));
+        self
+    }
+
+    pub fn initial_commit(mut self, message: &str) -> Self {
+        self.initial_commit = Some(message.to_string());
+        self
+    }
+```
+
+After file materialization in `build()` / `build_in()`, run shell commands in order:
+
+```rust
+if self.setup_git {
+    run_setup_command(path, "git init", &["git", "init"])?;
+}
+if let Some((name, email)) = &self.git_user {
+    run_setup_command(path, "git config user.name", &["git", "config", "user.name", name])?;
+    run_setup_command(path, "git config user.email", &["git", "config", "user.email", email])?;
+}
+if let Some(message) = &self.initial_commit {
+    run_setup_command(path, "git add .", &["git", "add", "."])?;
+    run_setup_command(path, "git commit", &["git", "commit", "-m", message])?;
+}
+```
+
+Implement a small helper in the same file:
+
+```rust
+fn run_setup_command(path: &Path, step: &str, args: &[&str]) -> Result<(), Error> {
+    let output = std::process::Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(path)
+        .output()
+        .map_err(|source| Error::ProjectSetup {
+            step: step.to_string(),
+            source,
+        })?;
+
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(Error::Pty(format!(
+            "project setup step {step} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        )))
+    }
+}
+```
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+Run:
+
+```bash
+cargo test -p scenario --test project
+```
+
+Expected: PASS including the new repository setup tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenario/src/error.rs crates/scenario/src/project.rs crates/scenario/tests/project.rs
+git commit -m "feat(scenario): add project git setup helpers"
+```
+
+---
+
+### Task 5: Verify the Full Phase-1 API Surface and Autotune-Style Example
+
+**Files:**
+- Modify: `crates/scenario/tests/session_flow.rs`
+- Modify: `crates/scenario/src/lib.rs` (docs only if needed)
+
+- [ ] **Step 1: Write the final integration test that mirrors the autotune-style flow**
+
+Add this test to `crates/scenario/tests/session_flow.rs`:
+
+```rust
+#[test]
+fn screen_helpers_replace_current_output_slicing_for_redraw_flows() {
+    let mut session = spawn(
+        r#"printf 'What metric?\n> Runtime performance\n  Memory usage';
+           sleep 0.1;
+           printf '\033[2A\r\033[J';
+           printf 'How should we measure?\n> Benchmark runtime\n  Track memory';
+           sleep 0.1"#,
+    );
+
+    session.expect("How should we measure").unwrap();
+    session.wait_for_screen_stable(Duration::from_millis(100)).unwrap();
+    session.expect_screen("How should we measure").unwrap();
+    session.expect_screen_not("Runtime performance").unwrap();
+    session.expect_screen("Benchmark runtime").unwrap();
+}
+```
+
+- [ ] **Step 2: Run the focused scenario crate test suite**
+
+Run:
+
+```bash
+cargo nextest run -p scenario
+```
+
+Expected: PASS with all existing and new tests green.
+
+- [ ] **Step 3: Run formatting and lint checks**
+
+Run:
+
+```bash
+cargo fmt --all --check
+cargo clippy -p scenario --all-targets --all-features -- -D warnings
+```
+
+Expected: both commands succeed with no output requiring follow-up changes.
+
+- [ ] **Step 4: Update public docs if needed**
+
+If `crates/scenario/src/lib.rs` module docs need a new example, add a short one using the new APIs:
+
+```rust
+//! let mut session = Scenario::new("my-cli")
+//!     .session_config(&SessionConfig::pty(100, 30).timeout(Duration::from_secs(5)))
+//!     .spawn()
+//!     .unwrap();
+//! session.send_keys([Key::Down, Key::Enter]).unwrap();
+//! session.expect_screen("Done").unwrap();
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/scenario/tests/session_flow.rs crates/scenario/src/lib.rs
+git commit -m "test(scenario): cover flow testing helpers end to end"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- Session action ergonomics: covered in Task 1
+- Screen-level expectations: covered in Task 2
+- Screen stabilization helper: covered in Task 2
+- Reusable session profiles: covered in Task 3
+- Project git setup actions: covered in Task 4
+- Autotune-style example/migration target: covered in Task 5
+- Optional flow helper (`step()`): intentionally deferred, matching the approved spec’s recommended scope
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “implement later” placeholders remain in the tasks
+- Each task includes concrete files, commands, and code snippets
+
+### Type consistency
+
+- `SessionConfig` is consistently named across tasks
+- Session helper names are consistent: `send_keys`, `press`, `enter`, `ctrl_c`, `visible_text`, `expect_screen`, `expect_screen_not`, `wait_for_screen_stable`
+- Error variant name is consistent: `ProjectSetup`
+

--- a/docs/superpowers/specs/2026-04-13-scenario-cli-flow-testing-design.md
+++ b/docs/superpowers/specs/2026-04-13-scenario-cli-flow-testing-design.md
@@ -1,0 +1,322 @@
+# Scenario Crate: Generic CLI Flow Testing
+
+**Date:** 2026-04-13
+**Status:** Draft for review
+
+## Problem
+
+`scenario` already covers process execution, PTY sessions, project fixtures, and a few low-level session helpers. That is enough to test interactive CLIs, but real dialog-driven tests still require too much hand-written harness code.
+
+The `autotune2` test suite shows the friction clearly:
+
+- repeated session setup boilerplate (`Scenario::new(...).terminal(...).timeout(...).spawn()`)
+- raw escape bytes for common navigation (`b"\x1b[B"`, `b"\r"`, `b"\x03"`)
+- brittle assertions against `current_output()` slices when what matters is the *visible screen*
+- repeated temporary project bootstrapping plus ad-hoc `git init` setup
+- imperative multi-step dialog tests that are verbose and harder to scan than the user flow they represent
+
+The goal is not to build an `autotune`-specific testing DSL. The goal is to let `scenario` define a CLI usage scenario and assert on expected user-visible behavior across a wide range of terminal interfaces.
+
+## Goals
+
+- Keep `scenario` generic and app-agnostic
+- Reduce boilerplate for interactive CLI and TUI tests
+- Improve reliability by preferring screen-level assertions over raw-output slicing
+- Add reusable project/setup helpers for common repository-backed CLI workflows
+- Preserve the current low-level APIs so advanced tests can still drop down to raw `Session` control
+
+## Non-Goals
+
+- Do not add application-specific concepts like “wizard”, “questionnaire”, or “approval dialog”
+- Do not replace the existing builder/session APIs
+- Do not create a large declarative DSL that hides process control completely
+- Do not assume every CLI has a stable full-screen TUI; line-oriented REPLs and mixed stdout/TTY apps must still fit
+
+## Design
+
+### 1. Session action ergonomics
+
+Add small, generic action helpers on top of `Session` so tests can express user intent instead of byte sequences.
+
+```rust
+impl Session {
+    pub fn send_keys<I>(&mut self, keys: I) -> Result<(), Error>
+    where
+        I: IntoIterator<Item = Key>;
+
+    pub fn press(&mut self, key: Key) -> Result<(), Error>;
+
+    pub fn enter(&mut self) -> Result<(), Error>;
+    pub fn ctrl_c(&mut self) -> Result<(), Error>;
+}
+```
+
+`send_key()` remains the primitive. The new methods are sugar only.
+
+**Why:**
+
+- `autotune2` repeatedly uses raw bytes for arrows, Enter, and Ctrl+C
+- tests become shorter and easier to scan
+- the API stays generic because it is still just terminal input
+
+### 2. Screen-level expectations
+
+The next gap is not input, but assertions. `visible_screen()` exists, but callers still have to manually fetch the screen and assert over `Vec<String>`.
+
+Add screen-oriented expectation helpers to `Session`:
+
+```rust
+impl Session {
+    pub fn expect_screen(&self, pattern: &str) -> Result<(), Error>;
+    pub fn expect_screen_regex(&self, pattern: &str) -> Result<(), Error>;
+
+    pub fn expect_screen_not(&self, pattern: &str) -> Result<(), Error>;
+    pub fn expect_screen_not_regex(&self, pattern: &str) -> Result<(), Error>;
+
+    pub fn visible_text(&self) -> String;
+}
+```
+
+Semantics:
+
+- `expect_screen*` checks the current visible screen, not the historical raw PTY stream
+- negative variants use the same quiet-period idea as `expect_not()`
+- `visible_text()` joins the visible screen into a newline-delimited string for simpler regex matching and debugging
+
+**Why:**
+
+- `autotune2` currently slices `current_output()` after `"How should we measure"` to infer that old menu items are gone
+- that is really a screen assertion, not a historical output assertion
+- screen-based checks are both shorter and less flaky for redraw-heavy interfaces
+
+### 3. Screen stabilization helper
+
+A common source of flaky PTY tests is checking the screen while the app is still redrawing.
+
+Add a generic “screen settled” primitive:
+
+```rust
+impl Session {
+    pub fn wait_for_screen_stable(&self, quiet_period: Duration) -> Result<(), Error>;
+}
+```
+
+Semantics:
+
+- sample the visible screen repeatedly
+- return once the screen is unchanged for the requested quiet period
+- fail on timeout using the session timeout
+
+This is intentionally low-level. Higher-level expectations can call it internally where appropriate, but it is also useful on its own before snapshot-like assertions.
+
+**Why:**
+
+- dialog UIs often repaint multiple times per keypress
+- a stable-screen primitive lowers flakiness without hardcoding arbitrary sleeps in tests
+
+### 4. Session builder defaults
+
+Interactive test files repeat the same setup:
+
+```rust
+Scenario::new(bin)
+    .current_dir(project.path())
+    .terminal(Terminal::pty(120, 40))
+    .timeout(Duration::from_secs(10))
+    .spawn()
+```
+
+Add optional reusable execution profiles:
+
+```rust
+pub struct SessionConfig {
+    pub terminal: Terminal,
+    pub timeout: Duration,
+}
+
+impl SessionConfig {
+    pub fn pty(cols: u16, rows: u16) -> Self;
+    pub fn timeout(self, timeout: Duration) -> Self;
+}
+
+impl Scenario {
+    pub fn session_config(self, config: &SessionConfig) -> Self;
+}
+```
+
+This is deliberately small. It avoids inventing a separate runner type while still letting callers define a shared test-local profile.
+
+**Why:**
+
+- repeated PTY shape/timeout boilerplate obscures the flow under test
+- a reusable config keeps `Scenario` generic and composable
+
+### 5. Project setup actions
+
+`Project` currently creates files and directories, but repo-backed tools still need post-build setup via ad-hoc shell commands.
+
+Add optional setup actions to `ProjectBuilder`:
+
+```rust
+impl ProjectBuilder {
+    pub fn setup_git(self) -> Self;
+    pub fn git_user(self, name: &str, email: &str) -> Self;
+    pub fn initial_commit(self, message: &str) -> Self;
+}
+```
+
+Build semantics:
+
+- file materialization still happens first
+- requested setup actions run after files exist
+- `setup_git()` initializes a repo
+- `git_user()` configures local author info
+- `initial_commit()` stages and commits current contents
+
+Error handling:
+
+- add a generic `ProjectSetup { step, source }` error variant for post-build setup failures
+
+**Why:**
+
+- `autotune2` repeatedly shells out to `git init`, `git add`, and `git commit`
+- repo initialization is a common CLI-testing need, not an autotune-specific one
+- keeping it inside `ProjectBuilder` makes fixtures more declarative
+
+### 6. Optional flow assertion helpers
+
+The highest-value abstraction above raw actions/assertions is a tiny flow helper, not a full DSL.
+
+```rust
+impl Session {
+    pub fn step(&mut self, visible_prompt: &str) -> Result<FlowStep<'_>, Error>;
+}
+
+pub struct FlowStep<'a> {
+    session: &'a mut Session,
+}
+
+impl FlowStep<'_> {
+    pub fn send_line(self, text: &str) -> Result<(), Error>;
+    pub fn press(self, key: Key) -> Result<(), Error>;
+    pub fn expect_screen_not(self, pattern: &str) -> Result<(), Error>;
+}
+```
+
+This is optional and intentionally thin. It should not become a custom scripting language. Its job is to group common “wait for prompt, act, assert cleanup” sequences into something easier to read.
+
+If this layer feels too magical during implementation, it should be dropped in favor of the lower-level pieces above. The first five sections are the core design; this sixth section is explicitly optional.
+
+## Example: Current vs Proposed
+
+### Current `autotune2` style
+
+```rust
+session.expect("What metric").unwrap();
+session.send(b"\x1b[B").unwrap();
+session.send(b"\x1b[B").unwrap();
+session.send(b"\r").unwrap();
+
+session.expect("How should we measure").unwrap();
+let output_so_far = session.current_output();
+if let Some(pos) = output_so_far.find("How should we measure") {
+    let after_second_q = &output_so_far[pos..];
+    assert!(!after_second_q.contains("Runtime performance"));
+}
+```
+
+### Proposed style
+
+```rust
+session.expect("What metric").unwrap();
+session.send_keys([Key::Down, Key::Down, Key::Enter]).unwrap();
+
+session.expect_screen("How should we measure").unwrap();
+session.expect_screen_not("Runtime performance").unwrap();
+```
+
+### Proposed repo fixture setup
+
+```rust
+let project = Project::empty()
+    .file(".autotune.toml", CONFIG_TOML)
+    .file("src/lib.rs", "pub fn hello() -> &'static str { \"hi\" }\n")
+    .setup_git()
+    .git_user("Test", "test@test.com")
+    .initial_commit("initial")
+    .build()?;
+```
+
+## API and Compatibility Strategy
+
+- All additions are additive
+- Existing `Scenario`, `Session`, `Project`, and `Key` APIs remain valid
+- Existing low-level methods stay the escape hatch for unsupported cases
+- The new helpers should be implemented in terms of the existing primitives wherever possible
+
+This keeps `scenario` useful both as:
+
+- a lightweight process runner for simple CLI tests
+- a higher-level flow-testing toolkit for interactive terminal applications
+
+## Testing Strategy
+
+Tests should prove the new APIs help with the exact generic behaviors they claim to support.
+
+### Session action ergonomics
+
+- `send_keys([Down, Enter])` sends the same bytes as repeated `send_key()`
+- `enter()` and `ctrl_c()` behave identically to their explicit key equivalents
+
+### Screen expectations
+
+- `expect_screen()` finds text visible after redraws even when historical output contains stale content
+- `expect_screen_not()` passes once prior menu content is no longer visible
+- regex variants work across joined screen lines
+
+### Screen stabilization
+
+- stable redraw loop eventually settles and passes
+- continuously mutating output times out cleanly
+
+### Project setup actions
+
+- `setup_git()` creates a usable repo
+- `git_user()` writes local config
+- `initial_commit()` creates the expected first commit
+- failure cases surface the setup step that failed
+
+### Integration examples
+
+Add or update `crates/scenario/tests/` coverage with small shell-driven PTY cases, plus at least one example that mirrors the autotune-style “prompt -> key navigation -> next prompt -> previous options disappeared” flow.
+
+## Risks and Trade-offs
+
+### Too much abstraction
+
+If the flow helper becomes a DSL, the crate gets harder to learn and more brittle to extend. The design avoids that by making the action/screen helpers the main value, with flow grouping as optional.
+
+### False confidence from screen assertions
+
+Screen assertions are right for user-visible behavior, but they should not replace historical-output assertions entirely. Some tests genuinely care about stream history. That is why `current_output()` and `expect()` stay intact.
+
+### Git setup portability
+
+Project setup actions rely on `git` being available. That is acceptable because the feature is explicitly opt-in and repo-oriented tests already require git. Failures must produce clear errors.
+
+## Recommended Scope
+
+Implement in two phases:
+
+1. Core helpers
+   - `send_keys`, `press`, `enter`, `ctrl_c`
+   - `visible_text`
+   - `expect_screen*`
+   - `wait_for_screen_stable`
+   - `ProjectBuilder` git setup actions
+
+2. Evaluate whether flow grouping is still needed
+   - add `step()` only if the first phase still leaves significant boilerplate in autotune-like tests
+
+This keeps the first implementation grounded and avoids over-design.
+


### PR DESCRIPTION
## Summary

Commits previously-uncommitted local documentation changes. All changes are confined to `docs/`.

- **Regenerated API reference** for `ion-skill`, `ionem`, and `scenario`:
  - New module pages: `ion-skill/templates`, `ion-skill/tool_permission`, `ion-skill/workspace`, `scenario/screen`
  - New entries (`fetch_builtin_template`, `Key`, `SessionConfig`, `ScreenBuffer` re-exports), version bumps (`ionem` 0.2.0→0.2.1, `scenario` 0.1.1→0.2.0), and richer module summaries
  - `api-navigation.json` updated for the new pages
- **Binary-skills guide**: added a "Setting up CI" section documenting `ion ci`, the four generated files, `--force`, and the release-plz flow
- **Plan/spec docs**: added the scenario CLI flow-testing plan and design spec under `docs/superpowers/`

## Note for reviewers

The regeneration **blanks out** a few previously-populated module descriptions, since those modules currently lack a doc-comment summary:

- `ionem::error` — was "Error types for binary skill operations."
- `ionem::shell` — was "CLI tool descriptors and wrappers for git, cargo, and gh."
- New `ion-skill::tool_permission` and `scenario::screen` also render with empty descriptions

These are upstream doc-comment gaps surfaced by the generator, not hand edits. Worth adding `//!` summaries to those modules in a follow-up so the next regeneration restores them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)