### PR TITLE
feat(init): teach the next step and mark detected targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,4 +42,14 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
+      # Several tests create throwaway git repos and commit into them. CI
+      # runners have no default git identity, so `git commit` fails with exit
+      # 128 and a later `git rev-parse HEAD` reports an ambiguous 'HEAD'.
+      # Configure a deterministic identity (and default branch) so those tests
+      # pass regardless of the runner image.
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "Ion CI"
+          git config --global user.email "ci@ion.invalid"
+          git config --global init.defaultBranch main
       - run: cargo nextest run --all-features --profile ci

--- a/build.rs
+++ b/build.rs
@@ -33,7 +33,12 @@ fn main() {
                 "success": true,
                 "data": {
                     "targets": {"claude": ".claude/skills", "cursor": ".cursor/skills"},
-                    "manifest": "Ion.toml"
+                    "manifest": "Ion.toml",
+                    "agents_md": {"action": "created", "template": "builtin:generic"},
+                    "next": [
+                        "Fill in AGENTS.md to describe this project, its build/test commands, and conventions",
+                        "ion add <source>"
+                    ]
                 }
             })),
 

--- a/crates/ion-skill/src/templates.rs
+++ b/crates/ion-skill/src/templates.rs
@@ -8,11 +8,20 @@
 pub const BUILTIN_PREFIX: &str = "builtin:";
 
 /// List of available built-in template names.
-pub const AVAILABLE: &[&str] = &["rust", "python", "julia", "typescript", "rust+python"];
+pub const AVAILABLE: &[&str] = &[
+    "generic",
+    "rust",
+    "python",
+    "julia",
+    "typescript",
+    "rust+python",
+];
 
 /// Return the embedded template content for a given name, or `None` if unknown.
 pub fn get(name: &str) -> Option<&'static str> {
     match name {
+        // Fallback scaffold used when no language-specific template matches.
+        "generic" => Some(include_str!("templates/generic.md")),
         "rust" => Some(include_str!("templates/rust.md")),
         "python" => Some(include_str!("templates/python.md")),
         "julia" => Some(include_str!("templates/julia.md")),

--- a/crates/ion-skill/src/templates/generic.md
+++ b/crates/ion-skill/src/templates/generic.md
@@ -1,0 +1,30 @@
+# AGENTS.md
+
+This file gives AI coding agents the context they need to work in this
+repository. Keep it short and specific — it is loaded into the agent's context
+on every session, so prune anything that isn't broadly useful.
+
+## Project
+
+<!-- One or two sentences: what this project is and what it does. -->
+
+## Setup & commands
+
+<!-- How to build, test, run, and lint. For example:
+
+```bash
+make build      # build
+make test        # run the test suite
+make lint        # lint / format check
+```
+-->
+
+## Conventions
+
+<!-- Code style, naming, directory layout, and any patterns agents should
+follow (or avoid). -->
+
+## Notes
+
+<!-- Anything else an agent should know: gotchas, do-nots, how changes are
+reviewed and merged. -->

--- a/skills/dogfooding-ion/SKILL.md
+++ b/skills/dogfooding-ion/SKILL.md
@@ -280,12 +280,28 @@ rather than re-deriving them.
 | `ion init` didn't link already-installed skills to a *newly*-configured target — they stayed invisible to that tool, no error | ergonomics (dead-end) | re-`deploy()` tracked skills after a target is added — `src/commands/init.rs` |
 | `ion list` rendered local skills as `vunknown` with a blank `source:` | human | show `(local)` / `source: local` — `src/commands/list.rs` |
 
-Still open from that pass (documented, not yet fixed): commands ending at a bare
-file list with no next-step line (`init`/`add`/`new` cold start), empty `ion
-list` giving no pointer to `ion init`, and `ion migrate` re-prompting for skills
-already registered as local. These are the natural next targets — the
-*progressive-prompting* core — and they want careful, general next-step logic
-(that respects actual state), not a quick hard-coded line.
+## Confirmed & fixed (second pass, 2026-07 — `ion init` journey)
+
+Driving `ion init` on a real project (a repo that already had `.claude/` and
+the built-in `ion-cli` deployed but no manifest) surfaced these and fixed them.
+
+| Symptom | Lens | Fix + where it lives |
+|---|---|---|
+| `ion init` ended at a bare "Created Ion.toml with N target(s)" file-list with **no next step** — neither the human text nor the `--json` envelope told the reader to add a skill | prompting (both channels) | state-aware next-step: fresh project → `ion add <source>` / `ion search <query>`; skills already declared → `ion add`. One source of truth (`next_steps_after_init`) rendered to human text *and* a new JSON `data.next` array — `src/commands/init.rs` |
+| No-TTY `ion init` (no `--target`) exposed a per-target `detected` flag to the agent in `--json`, but the human plain-text target list gave no such signal and the recovery example hard-coded `--target claude` | prompting (channel mismatch) | mark `(detected)` on targets whose dir already exists in the repo, and prefer a detected target in the `--target <name>` example — `src/commands/init.rs` |
+
+Note on `ion-cli = { type = "local" }`: the built-in skill is *intentionally*
+registered as `local` (see `builtin_skill::ensure_installed`) so it's skipped by
+fetch/validate/update and refreshed via `refresh_global` — not a bug. Callers
+reasoning about *user* skills should exclude `builtin_skill::SKILL_NAME` (the
+init next-step counter now does).
+
+Still open (documented, not yet fixed): `ion add`/`ion new` cold start still end
+without a next-step line (only `init` is now covered), empty `ion list` gives no
+pointer to `ion init`, and `ion migrate` re-prompts for skills already registered
+as local. These remain the natural next targets — the *progressive-prompting*
+core — and want careful, general next-step logic (that respects actual state),
+not a quick hard-coded line.
 
 ## Guidelines
 

--- a/skills/dogfooding-ion/SKILL.md
+++ b/skills/dogfooding-ion/SKILL.md
@@ -296,6 +296,28 @@ fetch/validate/update and refreshed via `refresh_global` — not a bug. Callers
 reasoning about *user* skills should exclude `builtin_skill::SKILL_NAME` (the
 init next-step counter now does).
 
+## Confirmed & fixed (third pass, 2026-07 — `ion init` AGENTS.md handling)
+
+`ion init` only offered AGENTS.md setup interactively (TTY-gated) *and* only
+when a language template was detected — so on a piped/agent run, or a project
+with no recognized stack, it silently created no AGENTS.md and never migrated an
+existing CLAUDE.md. Reworked so init *always* ensures an ion-managed AGENTS.md.
+
+| Symptom | Lens | Fix + where it lives |
+|---|---|---|
+| `ion init` created no AGENTS.md unless run in a TTY *and* a language template matched; agent/CI runs and generic projects got nothing | ergonomics (dead-end) | always ensure AGENTS.md in every channel; new `builtin:generic` fallback template — `crates/ion-skill/src/templates/generic.md`, `templates.rs`, `src/commands/init.rs` `ensure_agents_md` |
+| `ion init` never migrated an existing `CLAUDE.md` (only `ion migrate` did) — a repo with hand-written CLAUDE.md stayed unmanaged after init | ergonomics | init reconciles CLAUDE.md silently: rename→AGENTS.md + symlink back, or skip a genuine two-file conflict with an init-appropriate note — `ensure_agents_md` + `migrate_claude_md` gains a `rename_without_prompt` param |
+| After scaffolding from a template, nothing told the human/agent the file has placeholders to fill in | prompting (both channels) | when a template was applied, the first `next` step (human list + JSON `data.next`) is "Fill in AGENTS.md …" — `next_steps_after_init` keyed on `AgentsMdOutcome::created_from_template()` |
+| init's JSON success lacked any AGENTS.md signal for agents | agent | added `data.agents_md` = `{action: created\|migrated\|existing\|skipped\|disabled, template?}` mirroring the human summary — `src/commands/init.rs`, contract doc `skills/ion-cli/SKILL.md.j2` + `build.rs` |
+
+Design notes: `agents init`'s file-work was extracted into a non-printing
+`agents::apply_template` so both `agents init` and `ion init` share it without
+double-emitting a JSON envelope (the first-pass purity trap). An existing
+hand-written AGENTS.md is made ion-managed by symlink only — no `[agents]`
+template is attached to the user's own content (that would produce a misleading
+`ion agents diff`). `--no-agents` opts out of the whole thing. `ion migrate`'s
+conservative `--yes` behavior (skip the rename) is preserved via the new param.
+
 Still open (documented, not yet fixed): `ion add`/`ion new` cold start still end
 without a next-step line (only `init` is now covered), empty `ion list` gives no
 pointer to `ion init`, and `ion migrate` re-prompts for skills already registered

--- a/skills/ion-cli/SKILL.md.j2
+++ b/skills/ion-cli/SKILL.md.j2
@@ -37,6 +37,13 @@ $ ion --json init --target claude --target cursor
 
 Without `--target`, returns exit 2 with available targets for you to choose from.
 
+`init` also ensures an ion-managed `AGENTS.md`: it migrates an existing
+`CLAUDE.md` into `AGENTS.md` (linking `CLAUDE.md` back to it), or creates one
+from a detected language template — falling back to `builtin:generic`. The
+`data.agents_md.action` is one of `created`, `migrated`, `existing`, `skipped`
+(a two-file conflict), or `disabled`. When a template was applied, `data.next`
+prompts you to fill in `AGENTS.md`. Pass `--no-agents` to skip this entirely.
+
 ### Search for skills
 
 ```bash
@@ -250,6 +257,7 @@ $ ion run mytool [args...]      # runs the compiled binary
 | `--skills a,b,c` | `add` | Select specific skills from a collection |
 | `--yes` / `-y` | `remove` | Skip removal confirmation |
 | `--target name` | `init` | Specify targets non-interactively |
+| `--no-agents` | `init` | Skip AGENTS.md creation and CLAUDE.md migration |
 | `--path <dir>` | `new` | Target directory for new skill |
-| `--builtin <name>` | `agents init` | Use a built-in AGENTS.md template (rust, python, julia, rust+python) |
+| `--builtin <name>` | `agents init` | Use a built-in AGENTS.md template (generic, rust, python, julia, rust+python) |
 | `--force` | `init`, `new` | Overwrite existing files |

--- a/src/builtin_skill.rs
+++ b/src/builtin_skill.rs
@@ -5,7 +5,11 @@ use ion_skill::manifest::ManifestOptions;
 use ion_skill::manifest_writer;
 use ion_skill::source::SkillSource;
 
-const SKILL_NAME: &str = "ion-cli";
+/// Name of the built-in skill that Ion installs into every project so agents
+/// can discover its JSON interface. Registered in Ion.toml as a `local` skill
+/// but managed by Ion (symlinked to global storage, gitignored), so callers
+/// that reason about "user" skills should exclude it.
+pub const SKILL_NAME: &str = "ion-cli";
 const SKILL_CONTENT: &str = include_str!(concat!(env!("OUT_DIR"), "/SKILL.md"));
 
 /// Update the global SKILL.md if the embedded content has changed.

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -89,6 +89,103 @@ pub fn deploy_agents_update_skill(
     Ok(())
 }
 
+/// Result of applying an AGENTS.md template to a project.
+pub(crate) struct TemplateSetup {
+    /// Canonical template source recorded in Ion.toml (e.g. `builtin:rust`).
+    pub template: String,
+    /// True if a fresh AGENTS.md was written; false if AGENTS.md already
+    /// existed and the template was staged as `.agents/templates/AGENTS.md.upstream`.
+    pub created: bool,
+}
+
+/// Fetch a template and apply it to the project: write (or stage) AGENTS.md,
+/// record `[agents]` config + lock entry, gitignore the upstream staging file,
+/// create agent symlinks, and deploy the agents-update skill.
+///
+/// Performs no printing so it can be reused by both `agents init` (which prints
+/// a human summary or a JSON envelope) and `ion init` (which folds the result
+/// into its own output). The caller must reject a project that already has an
+/// `[agents]` template configured.
+pub(crate) fn apply_template(
+    project: &Project,
+    merged_options: &ion_skill::manifest::ManifestOptions,
+    global_config: &GlobalConfig,
+    source: &str,
+    rev: Option<&str>,
+    path: Option<&str>,
+) -> anyhow::Result<TemplateSetup> {
+    // Resolve built-in vs remote source and fetch the template content.
+    let (fetched, canonical_source) = if let Some(name) =
+        ion_skill::templates::parse_builtin_name(source)
+    {
+        if rev.is_some() {
+            anyhow::bail!("--rev cannot be used with built-in templates");
+        }
+        if path.is_some() {
+            anyhow::bail!("--path cannot be used with built-in templates");
+        }
+        let fetched = ion_skill::agents::fetch_builtin_template(name)?;
+        (fetched, format!("builtin:{name}"))
+    } else {
+        let resolved_source = global_config.resolve_source(source);
+        let fetched = ion_skill::agents::fetch_template(&resolved_source, rev, path, &project.dir)?;
+        (fetched, source.to_string())
+    };
+
+    let agents_md_path = project.dir.join("AGENTS.md");
+    let upstream_dir = project.dir.join(".agents/templates");
+    let upstream_path = upstream_dir.join("AGENTS.md.upstream");
+    let already_existed = agents_md_path.exists();
+
+    if already_existed {
+        // Existing AGENTS.md — stage upstream for merging rather than clobber it.
+        std::fs::create_dir_all(&upstream_dir)?;
+        std::fs::write(&upstream_path, &fetched.content)?;
+    } else {
+        std::fs::write(&agents_md_path, &fetched.content)?;
+    }
+
+    // Record [agents] config + lock entry.
+    ion_skill::manifest_writer::write_agents_config(
+        &project.manifest_path,
+        &canonical_source,
+        rev,
+        path,
+    )?;
+    let mut lockfile = project.lockfile()?;
+    lockfile.agents = Some(ion_skill::agents::AgentsLockEntry {
+        template: canonical_source.clone(),
+        rev: fetched.rev,
+        checksum: fetched.checksum,
+        updated_at: ion_skill::agents::now_iso8601(),
+    });
+    lockfile.write_to(&project.lockfile_path)?;
+
+    // Gitignore the upstream staging file.
+    let entries = [".agents/templates/AGENTS.md.upstream"];
+    let missing = ion_skill::gitignore::find_missing_gitignore_entries(&project.dir, &entries)?;
+    if !missing.is_empty() {
+        let refs: Vec<&str> = missing.iter().map(|s| s.as_str()).collect();
+        ion_skill::gitignore::append_to_gitignore(&project.dir, &refs)?;
+    }
+
+    // Create agent symlinks (e.g. CLAUDE.md -> AGENTS.md).
+    if let Err(e) = ion_skill::agents::ensure_agent_symlinks(&project.dir, &merged_options.targets)
+    {
+        log::warn!("Failed to create agent symlinks: {e}");
+    }
+
+    // Deploy the agents-update built-in skill.
+    if let Err(e) = deploy_agents_update_skill(project, merged_options) {
+        log::warn!("Failed to deploy agents-update skill: {e}");
+    }
+
+    Ok(TemplateSetup {
+        template: canonical_source,
+        created: !already_existed,
+    })
+}
+
 pub fn init(
     source: &str,
     rev: Option<&str>,
@@ -110,98 +207,36 @@ pub fn init(
         );
     }
 
-    // Detect built-in templates and normalize the source name
-    let (fetched, canonical_source) = if let Some(name) =
-        ion_skill::templates::parse_builtin_name(source)
-    {
-        if rev.is_some() {
-            anyhow::bail!("--rev cannot be used with built-in templates");
-        }
-        if path.is_some() {
-            anyhow::bail!("--path cannot be used with built-in templates");
-        }
-        let fetched = ion_skill::agents::fetch_builtin_template(name)?;
-        let canonical = format!("builtin:{name}");
-        (fetched, canonical)
-    } else {
-        let resolved_source = ws.global_config.resolve_source(source);
-        let fetched = ion_skill::agents::fetch_template(&resolved_source, rev, path, &project.dir)?;
-        (fetched, source.to_string())
-    };
-
-    let agents_md_path = project.dir.join("AGENTS.md");
-    let upstream_dir = project.dir.join(".agents/templates");
-    let upstream_path = upstream_dir.join("AGENTS.md.upstream");
-    let already_existed = agents_md_path.exists();
-
-    if already_existed {
-        // Existing AGENTS.md — stage upstream for merging
-        std::fs::create_dir_all(&upstream_dir)?;
-        std::fs::write(&upstream_path, &fetched.content)?;
-        if !json {
-            println!(
-                "{} AGENTS.md already exists — upstream template staged to {}",
-                p.warn("note:"),
-                p.dim(".agents/templates/AGENTS.md.upstream")
-            );
-            println!("  Merge changes manually or ask your agent to help.");
-        }
-    } else {
-        // No existing AGENTS.md — copy as starting point
-        std::fs::write(&agents_md_path, &fetched.content)?;
-        if !json {
-            println!("{} AGENTS.md from template", p.success("Created"));
-        }
-    }
-
-    // Write [agents] to Ion.toml
-    ion_skill::manifest_writer::write_agents_config(
-        &project.manifest_path,
-        &canonical_source,
+    let agents_md_existed = project.dir.join("AGENTS.md").exists();
+    let merged_options = ws.merged_options_for(project)?;
+    let setup = apply_template(
+        project,
+        &merged_options,
+        &ws.global_config,
+        source,
         rev,
         path,
     )?;
 
-    // Write lock entry
-    let mut lockfile = project.lockfile()?;
-    lockfile.agents = Some(ion_skill::agents::AgentsLockEntry {
-        template: canonical_source.clone(),
-        rev: fetched.rev,
-        checksum: fetched.checksum,
-        updated_at: ion_skill::agents::now_iso8601(),
-    });
-    lockfile.write_to(&project.lockfile_path)?;
-
-    // Add specific gitignore entry for the upstream staging file
-    let entries = [".agents/templates/AGENTS.md.upstream"];
-    let missing = ion_skill::gitignore::find_missing_gitignore_entries(&project.dir, &entries)?;
-    if !missing.is_empty() {
-        let refs: Vec<&str> = missing.iter().map(|s| s.as_str()).collect();
-        ion_skill::gitignore::append_to_gitignore(&project.dir, &refs)?;
-    }
-
-    // Create agent symlinks (e.g. CLAUDE.md -> AGENTS.md)
-    let merged_options = ws.merged_options_for(project)?;
-    if let Err(e) = ion_skill::agents::ensure_agent_symlinks(&project.dir, &merged_options.targets)
-    {
-        log::warn!("Failed to create agent symlinks: {e}");
-    }
-
-    // Deploy agents-update built-in skill
-    if let Err(e) = deploy_agents_update_skill(project, &merged_options) {
-        log::warn!("Failed to deploy agents-update skill: {e}");
-    }
-
-    if !json {
-        println!("  {} Ion.toml with template source", p.success("Updated"));
-    }
-
     if json {
         crate::json::print_success(serde_json::json!({
-            "template": canonical_source,
-            "agents_md_created": !already_existed,
+            "template": setup.template,
+            "agents_md_created": setup.created,
         }));
+        return Ok(());
     }
+
+    if agents_md_existed {
+        println!(
+            "{} AGENTS.md already exists — upstream template staged to {}",
+            p.warn("note:"),
+            p.dim(".agents/templates/AGENTS.md.upstream")
+        );
+        println!("  Merge changes manually or ask your agent to help.");
+    } else {
+        println!("{} AGENTS.md from template", p.success("Created"));
+    }
+    println!("  {} Ion.toml with template source", p.success("Updated"));
 
     Ok(())
 }
@@ -485,6 +520,7 @@ pub(crate) fn migrate_claude_md(
     p: &Paint,
     json: bool,
     yes: bool,
+    rename_without_prompt: bool,
 ) -> anyhow::Result<Option<AgentsMdAction>> {
     let agents_path = project_dir.join("AGENTS.md");
     let claude_path = project_dir.join("CLAUDE.md");
@@ -599,6 +635,19 @@ pub(crate) fn migrate_claude_md(
         // No AGENTS.md + CLAUDE.md has real content → rename.
         (false, false) => {
             if yes || json {
+                // Non-interactive. When the caller opts in (e.g. `ion init`),
+                // perform the unambiguous rename directly; otherwise (e.g.
+                // `ion migrate --yes`) leave the rename as an explicit choice.
+                if rename_without_prompt {
+                    std::fs::rename(&claude_path, &agents_path)?;
+                    #[cfg(unix)]
+                    std::os::unix::fs::symlink("AGENTS.md", &claude_path)?;
+                    ion_skill::gitignore::ensure_agent_file_ignored(project_dir, "CLAUDE.md")?;
+                    if !json {
+                        println!("  Renamed CLAUDE.md to AGENTS.md, created symlink.");
+                    }
+                    return Ok(Some(AgentsMdAction::Renamed { backup: None }));
+                }
                 let reason =
                     "CLAUDE.md has content but no AGENTS.md — run without --yes to confirm rename"
                         .to_string();

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::io::{IsTerminal, Write};
+use std::io::IsTerminal;
 use std::path::Path;
 
 use crate::context::WorkspaceContext;
@@ -107,39 +107,203 @@ pub fn print_no_targets_hint(
     }
 }
 
-/// The next-step commands to suggest after a successful `init`, tailored to
-/// whether the project already has user skills registered. Returned as plain
-/// command strings so the human text and the JSON `next` field render from a
-/// single source of truth.
-fn next_steps_after_init(real_skill_count: usize) -> Vec<&'static str> {
-    if real_skill_count > 0 {
-        // Skills are already declared in Ion.toml (e.g. a re-init, or a repo
-        // cloned with a manifest) — the next move is to install them.
-        vec!["ion add"]
-    } else {
-        // Fresh project with no user skills yet — point at discovering/adding
-        // the first one.
-        vec!["ion add <source>", "ion search <query>"]
+/// A suggested next step after `init`. Rendered to both the human text (with
+/// its command emphasized) and the JSON `next` array (as a plain string) from
+/// this single definition, so the two channels never drift.
+struct NextStep {
+    /// Imperative shown to the human, e.g. "Add your first skill".
+    label: String,
+    /// Exact command to run, if this step is a command.
+    command: Option<String>,
+    /// Extra parenthetical guidance (e.g. a discovery command).
+    hint: Option<String>,
+}
+
+impl NextStep {
+    /// Plain-string form emitted in the JSON `next` array. Agents get the exact
+    /// command when there is one, otherwise the imperative label.
+    fn to_json_string(&self) -> String {
+        match &self.command {
+            Some(cmd) => cmd.clone(),
+            None => self.label.clone(),
+        }
+    }
+
+    /// Styled single-line form for the human channel.
+    fn to_human(&self, p: &crate::style::Paint) -> String {
+        let mut line = self.label.clone();
+        if let Some(cmd) = &self.command {
+            line.push_str(&format!(" — {}", p.bold(cmd)));
+        }
+        if let Some(hint) = &self.hint {
+            line.push_str(&format!(" ({hint})"));
+        }
+        line
     }
 }
 
-/// Print the next-step guidance after a successful `init` (human channel).
-fn print_next_steps_after_init(p: &crate::style::Paint, real_skill_count: usize) {
-    println!();
-    if real_skill_count > 0 {
-        println!(
-            "  {}: install the skills declared in Ion.toml — {}",
-            p.bold("Next"),
-            p.bold("ion add")
-        );
-    } else {
-        println!(
-            "  {}: add your first skill — {} (browse skills with {})",
-            p.bold("Next"),
-            p.bold("ion add <source>"),
-            p.bold("ion search <query>")
-        );
+/// Build the ordered next-step list after a successful `init`, tailored to
+/// what init just did. This is the single source of truth for both channels.
+fn next_steps_after_init(created_agents_md: bool, real_skill_count: usize) -> Vec<NextStep> {
+    let mut steps = Vec::new();
+
+    // Whenever init created AGENTS.md from a template, the file has placeholder
+    // sections — prompt the human/agent to fill them in before anything else.
+    if created_agents_md {
+        steps.push(NextStep {
+            label: "Fill in AGENTS.md to describe this project, its build/test commands, and conventions".to_string(),
+            command: None,
+            hint: None,
+        });
     }
+
+    if real_skill_count > 0 {
+        // Skills already declared in Ion.toml (re-init, or a cloned manifest) —
+        // the next move is to install them.
+        steps.push(NextStep {
+            label: "Install the skills declared in Ion.toml".to_string(),
+            command: Some("ion add".to_string()),
+            hint: None,
+        });
+    } else {
+        // Fresh project with no user skills yet — add the first one.
+        steps.push(NextStep {
+            label: "Add your first skill".to_string(),
+            command: Some("ion add <source>".to_string()),
+            hint: Some("browse skills with `ion search <query>`".to_string()),
+        });
+    }
+
+    steps
+}
+
+/// Print the next-step guidance after a successful `init` (human channel).
+fn print_next_steps(p: &crate::style::Paint, steps: &[NextStep]) {
+    if steps.is_empty() {
+        return;
+    }
+    println!();
+    if steps.len() == 1 {
+        println!("  {}: {}", p.bold("Next"), steps[0].to_human(p));
+    } else {
+        println!("  {}:", p.bold("Next steps"));
+        for (i, step) in steps.iter().enumerate() {
+            println!("    {}. {}", i + 1, step.to_human(p));
+        }
+    }
+}
+
+/// What `init` did about the project's AGENTS.md.
+enum AgentsMdOutcome {
+    /// `--no-agents`: skipped entirely.
+    Disabled,
+    /// Wrote a fresh AGENTS.md from a template.
+    Created { template: String },
+    /// Renamed an existing CLAUDE.md into AGENTS.md and linked it back.
+    Migrated,
+    /// AGENTS.md already existed; ensured agent tools link to it.
+    Existing,
+    /// AGENTS.md and CLAUDE.md both have content; left both untouched.
+    ConflictSkipped { reason: String },
+}
+
+impl AgentsMdOutcome {
+    fn to_json(&self) -> serde_json::Value {
+        match self {
+            AgentsMdOutcome::Disabled => serde_json::json!({"action": "disabled"}),
+            AgentsMdOutcome::Created { template } => {
+                serde_json::json!({"action": "created", "template": template})
+            }
+            AgentsMdOutcome::Migrated => {
+                serde_json::json!({"action": "migrated", "from": "CLAUDE.md"})
+            }
+            AgentsMdOutcome::Existing => serde_json::json!({"action": "existing"}),
+            AgentsMdOutcome::ConflictSkipped { reason } => {
+                serde_json::json!({"action": "skipped", "reason": reason})
+            }
+        }
+    }
+
+    /// True when init wrote a fresh AGENTS.md from a template (so the user
+    /// should be prompted to fill it in).
+    fn created_from_template(&self) -> bool {
+        matches!(self, AgentsMdOutcome::Created { .. })
+    }
+}
+
+/// Ensure the project has an ion-managed AGENTS.md.
+///
+/// 1. Reconcile any existing CLAUDE.md into AGENTS.md (rename the unambiguous
+///    case, replace a pointer with a symlink, or skip a genuine two-file
+///    conflict). This runs silently and non-interactively; `init` narrates the
+///    result itself so the messaging is consistent and init-appropriate.
+/// 2. If AGENTS.md still doesn't exist, create it from a detected language
+///    template, or a generic scaffold when no language matches.
+fn ensure_agents_md(
+    project: &ion_skill::workspace::Project,
+    merged_options: &ion_skill::manifest::ManifestOptions,
+    global_config: &ion_skill::config::GlobalConfig,
+    p: &crate::style::Paint,
+) -> anyhow::Result<AgentsMdOutcome> {
+    use crate::commands::agents::{AgentsMdAction, migrate_claude_md};
+
+    let agents_md = project.dir.join("AGENTS.md");
+
+    // Reconcile an existing CLAUDE.md silently (json=true suppresses migrate's
+    // own prompts and prints), auto-renaming the unambiguous case.
+    let migration = migrate_claude_md(&project.dir, p, true, true, true)?;
+
+    match migration {
+        Some(AgentsMdAction::Renamed { .. }) => Ok(AgentsMdOutcome::Migrated),
+        Some(AgentsMdAction::Symlinked) => Ok(AgentsMdOutcome::Existing),
+        Some(AgentsMdAction::Skipped { .. }) => {
+            if agents_md.exists() {
+                // Genuine conflict — both files have real content. Use an
+                // init-appropriate reason (migrate's mentions `--yes`).
+                Ok(AgentsMdOutcome::ConflictSkipped {
+                    reason: "AGENTS.md and CLAUDE.md both have content; kept both".to_string(),
+                })
+            } else {
+                // e.g. a CLAUDE.md pointing at a nonexistent AGENTS.md — create one.
+                create_agents_from_template(project, merged_options, global_config)
+            }
+        }
+        None => {
+            // No CLAUDE.md file to migrate.
+            if agents_md.exists() {
+                if let Err(e) =
+                    ion_skill::agents::ensure_agent_symlinks(&project.dir, &merged_options.targets)
+                {
+                    log::warn!("Failed to create agent symlinks: {e}");
+                }
+                Ok(AgentsMdOutcome::Existing)
+            } else {
+                create_agents_from_template(project, merged_options, global_config)
+            }
+        }
+    }
+}
+
+/// Create AGENTS.md from the best-matching built-in template (or the generic
+/// fallback), wiring up `[agents]` tracking and agent symlinks.
+fn create_agents_from_template(
+    project: &ion_skill::workspace::Project,
+    merged_options: &ion_skill::manifest::ManifestOptions,
+    global_config: &ion_skill::config::GlobalConfig,
+) -> anyhow::Result<AgentsMdOutcome> {
+    let template = detect_builtin_template(&project.dir).unwrap_or("generic");
+    let source = format!("builtin:{template}");
+    let setup = crate::commands::agents::apply_template(
+        project,
+        merged_options,
+        global_config,
+        &source,
+        None,
+        None,
+    )?;
+    Ok(AgentsMdOutcome::Created {
+        template: setup.template,
+    })
 }
 
 /// Detect likely built-in AGENTS.md template from project files.
@@ -164,33 +328,10 @@ fn detect_builtin_template(dir: &Path) -> Option<&'static str> {
     }
 }
 
-/// Prompt the user to set up an AGENTS.md template. Returns the chosen template
-/// name, or `None` if the user declined or the prompt was skipped.
-fn prompt_agents_template(dir: &Path) -> anyhow::Result<Option<String>> {
-    if !std::io::stdin().is_terminal() {
-        return Ok(None);
-    }
-    let detected = detect_builtin_template(dir);
-    match detected {
-        Some(name) => {
-            print!("  Set up AGENTS.md? [Y/n] (template: {name}) ");
-            std::io::stdout().flush()?;
-            let mut line = String::new();
-            std::io::stdin().read_line(&mut line)?;
-            let answer = line.trim();
-            if answer.is_empty() || answer.eq_ignore_ascii_case("y") {
-                Ok(Some(name.to_string()))
-            } else {
-                Ok(None)
-            }
-        }
-        None => Ok(None),
-    }
-}
-
 pub fn run(
     targets: &[String],
     force: bool,
+    no_agents: bool,
     json: bool,
     project_flags: &[String],
 ) -> anyhow::Result<()> {
@@ -298,24 +439,6 @@ pub fn run(
         }
     }
 
-    // Create agent file symlinks (e.g. CLAUDE.md -> AGENTS.md)
-    if let Err(e) = ion_skill::agents::ensure_agent_symlinks(&project.dir, &merged_options.targets)
-    {
-        log::warn!("Failed to create agent symlinks: {e}");
-    }
-
-    // Deploy agents-update skill if [agents] template is configured
-    if manifest
-        .agents
-        .as_ref()
-        .and_then(|a| a.template.as_ref())
-        .is_some()
-        && let Err(e) =
-            crate::commands::agents::deploy_agents_update_skill(&project, &merged_options)
-    {
-        log::warn!("Failed to deploy agents-update skill: {e}");
-    }
-
     // Auto-register in workspace if we're inside one
     if ws.is_workspace() {
         let root = ws.root_project();
@@ -342,46 +465,39 @@ pub fn run(
         }
     }
 
-    // Offer inline AGENTS.md setup on fresh init (non-json, interactive, no existing AGENTS.md)
-    let agents_template_used = if !json && !manifest_existed {
-        let agents_md_path = project.dir.join("AGENTS.md");
-        if !agents_md_path.exists() {
-            match prompt_agents_template(&project.dir)? {
-                Some(name) => {
-                    let source = format!("builtin:{name}");
-                    match crate::commands::agents::init(&source, None, None, false, project_flags) {
-                        Ok(()) => Some(name),
-                        Err(e) => {
-                            eprintln!("  warning: AGENTS.md setup failed: {e}");
-                            None
-                        }
-                    }
-                }
-                None => None,
-            }
-        } else {
-            None
-        }
+    // Ensure the project has an ion-managed AGENTS.md: migrate an existing
+    // CLAUDE.md, or create one from a template. Runs in every channel; skipped
+    // entirely with `--no-agents`.
+    let agents_outcome = if no_agents {
+        AgentsMdOutcome::Disabled
     } else {
-        None
+        match ensure_agents_md(&project, &merged_options, &ws.global_config, &p) {
+            Ok(outcome) => outcome,
+            Err(e) => {
+                if !json {
+                    eprintln!("  {}: AGENTS.md setup failed: {e}", p.warn("warning"));
+                }
+                AgentsMdOutcome::Disabled
+            }
+        }
     };
 
-    // Count user skills registered in the manifest (excluding the built-in
-    // ion-cli, which Ion manages itself). This decides which next step to
-    // suggest: install existing skills, or add the first one.
+    // Count user skills registered in the manifest (excluding Ion-managed
+    // built-ins). This decides which next step to suggest: install existing
+    // skills, or add the first one.
     let real_skill_count = manifest
         .skills
         .keys()
-        .filter(|n| n.as_str() != crate::builtin_skill::SKILL_NAME)
+        .filter(|n| !is_managed_skill(n))
         .count();
-    let next = next_steps_after_init(real_skill_count);
+    let next = next_steps_after_init(agents_outcome.created_from_template(), real_skill_count);
 
     if json {
         crate::json::print_success(serde_json::json!({
             "targets": resolved,
             "manifest": "Ion.toml",
-            "agents_template": agents_template_used,
-            "next": next,
+            "agents_md": agents_outcome.to_json(),
+            "next": next.iter().map(NextStep::to_json_string).collect::<Vec<_>>(),
         }));
         return Ok(());
     }
@@ -399,14 +515,57 @@ pub fn run(
         }
     }
 
+    print_agents_outcome(&p, &agents_outcome);
+
     // Show hint if any resolved target looks like codex
     if resolved.keys().any(|k| k.eq_ignore_ascii_case("codex")) {
         print_codex_hint(&p);
     }
 
-    print_next_steps_after_init(&p, real_skill_count);
+    print_next_steps(&p, &next);
 
     Ok(())
+}
+
+/// Whether a skill name is one Ion manages itself (not a user skill).
+fn is_managed_skill(name: &str) -> bool {
+    name == crate::builtin_skill::SKILL_NAME || name == "agents-update"
+}
+
+/// Print the human-channel summary line for what init did about AGENTS.md.
+fn print_agents_outcome(p: &crate::style::Paint, outcome: &AgentsMdOutcome) {
+    match outcome {
+        AgentsMdOutcome::Disabled => {}
+        AgentsMdOutcome::Created { template } => {
+            let name = template.strip_prefix("builtin:").unwrap_or(template);
+            println!(
+                "  {} AGENTS.md from the {} template",
+                p.success("Created"),
+                p.bold(name)
+            );
+        }
+        AgentsMdOutcome::Migrated => {
+            println!(
+                "  {} CLAUDE.md → AGENTS.md ({} now links to it)",
+                p.success("Migrated"),
+                p.dim("CLAUDE.md")
+            );
+        }
+        AgentsMdOutcome::Existing => {
+            println!(
+                "  {} AGENTS.md (linked agent tools to it)",
+                p.success("Using")
+            );
+        }
+        AgentsMdOutcome::ConflictSkipped { reason } => {
+            println!(
+                "  {}: {} — merge them manually, or run {} to resolve interactively",
+                p.warn("note"),
+                reason,
+                p.bold("ion migrate")
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -107,6 +107,41 @@ pub fn print_no_targets_hint(
     }
 }
 
+/// The next-step commands to suggest after a successful `init`, tailored to
+/// whether the project already has user skills registered. Returned as plain
+/// command strings so the human text and the JSON `next` field render from a
+/// single source of truth.
+fn next_steps_after_init(real_skill_count: usize) -> Vec<&'static str> {
+    if real_skill_count > 0 {
+        // Skills are already declared in Ion.toml (e.g. a re-init, or a repo
+        // cloned with a manifest) — the next move is to install them.
+        vec!["ion add"]
+    } else {
+        // Fresh project with no user skills yet — point at discovering/adding
+        // the first one.
+        vec!["ion add <source>", "ion search <query>"]
+    }
+}
+
+/// Print the next-step guidance after a successful `init` (human channel).
+fn print_next_steps_after_init(p: &crate::style::Paint, real_skill_count: usize) {
+    println!();
+    if real_skill_count > 0 {
+        println!(
+            "  {}: install the skills declared in Ion.toml — {}",
+            p.bold("Next"),
+            p.bold("ion add")
+        );
+    } else {
+        println!(
+            "  {}: add your first skill — {} (browse skills with {})",
+            p.bold("Next"),
+            p.bold("ion add <source>"),
+            p.bold("ion search <query>")
+        );
+    }
+}
+
 /// Detect likely built-in AGENTS.md template from project files.
 fn detect_builtin_template(dir: &Path) -> Option<&'static str> {
     let has_cargo = dir.join("Cargo.toml").exists();
@@ -212,11 +247,25 @@ pub fn run(
         println!("No target specified and no interactive terminal available.");
         println!();
         println!("Available targets:");
-        for (name, _dir, path) in KNOWN_TARGETS {
-            println!("  {name} -> {path}");
+        // Mark targets whose directory already exists in this project. This
+        // mirrors the `detected` flag the --json channel exposes, so a human
+        // reading the plain-text list gets the same signal an agent does.
+        let mut first_detected: Option<&str> = None;
+        for (name, dir, path) in KNOWN_TARGETS {
+            if project.dir.join(dir).exists() {
+                if first_detected.is_none() {
+                    first_detected = Some(name);
+                }
+                println!("  {name} -> {path} {}", p.dim("(detected)"));
+            } else {
+                println!("  {name} -> {path}");
+            }
         }
         println!();
-        println!("Re-run with --target <name> to select targets (e.g. --target claude).");
+        // Prefer a detected target in the example so the recovery command lands
+        // on the tool this repo is already set up for.
+        let example = first_detected.unwrap_or("claude");
+        println!("Re-run with --target <name> to select targets (e.g. --target {example}).");
         anyhow::bail!("no targets selected; re-run with --target <name>");
     } else {
         match select_targets_interactive(&project.dir)? {
@@ -317,11 +366,22 @@ pub fn run(
         None
     };
 
+    // Count user skills registered in the manifest (excluding the built-in
+    // ion-cli, which Ion manages itself). This decides which next step to
+    // suggest: install existing skills, or add the first one.
+    let real_skill_count = manifest
+        .skills
+        .keys()
+        .filter(|n| n.as_str() != crate::builtin_skill::SKILL_NAME)
+        .count();
+    let next = next_steps_after_init(real_skill_count);
+
     if json {
         crate::json::print_success(serde_json::json!({
             "targets": resolved,
             "manifest": "Ion.toml",
             "agents_template": agents_template_used,
+            "next": next,
         }));
         return Ok(());
     }
@@ -343,6 +403,8 @@ pub fn run(
     if resolved.keys().any(|k| k.eq_ignore_ascii_case("codex")) {
         print_codex_hint(&p);
     }
+
+    print_next_steps_after_init(&p, real_skill_count);
 
     Ok(())
 }

--- a/src/commands/migrate.rs
+++ b/src/commands/migrate.rs
@@ -619,5 +619,7 @@ fn migrate_agents_md(
     json: bool,
     yes: bool,
 ) -> anyhow::Result<Option<crate::commands::agents::AgentsMdAction>> {
-    crate::commands::agents::migrate_claude_md(project_dir, p, json, yes)
+    // `ion migrate` keeps the rename as an explicit choice: with --yes it skips
+    // the CLAUDE.md → AGENTS.md rename rather than performing it silently.
+    crate::commands::agents::migrate_claude_md(project_dir, p, json, yes, false)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,9 @@ enum Commands {
         /// Overwrite existing files
         #[arg(long)]
         force: bool,
+        /// Skip AGENTS.md creation and CLAUDE.md migration
+        #[arg(long)]
+        no_agents: bool,
     },
     /// Set up GitHub Actions CI/CD for a binary skill project
     Ci {
@@ -323,6 +326,7 @@ fn main() {
             ci,
             target,
             force,
+            no_agents,
         } => {
             if bin {
                 commands::new::run_bin(path.as_deref(), ci, force, json)
@@ -331,7 +335,7 @@ fn main() {
                     "--ci requires --bin (CI/CD setup is for binary skill projects)"
                 ))
             } else {
-                commands::init::run(&target, force, json, &project_flags)
+                commands::init::run(&target, force, no_agents, json, &project_flags)
             }
         }
         Commands::Ci { force } => commands::ci::run(force, json),

--- a/tests/agents_integration.rs
+++ b/tests/agents_integration.rs
@@ -125,7 +125,7 @@ fn init_creates_claude_symlink_when_agents_md_exists() {
 }
 
 #[test]
-fn init_no_symlink_without_agents_md() {
+fn init_creates_agents_md_and_symlink_by_default() {
     let project = tempfile::tempdir().unwrap();
 
     let output = ion_cmd()
@@ -135,6 +135,32 @@ fn init_no_symlink_without_agents_md() {
         .unwrap();
     assert!(output.status.success());
 
+    // init now scaffolds an ion-managed AGENTS.md and links CLAUDE.md to it.
+    assert!(
+        project.path().join("AGENTS.md").exists(),
+        "init should create AGENTS.md by default"
+    );
+    let meta = std::fs::symlink_metadata(project.path().join("CLAUDE.md")).unwrap();
+    assert!(
+        meta.is_symlink(),
+        "CLAUDE.md should be a symlink to AGENTS.md"
+    );
+}
+
+#[test]
+fn init_no_symlink_when_agents_disabled() {
+    // Invariant: never a dangling CLAUDE.md symlink without an AGENTS.md.
+    // With --no-agents, init creates neither file.
+    let project = tempfile::tempdir().unwrap();
+
+    let output = ion_cmd()
+        .args(["init", "--target", "claude", "--no-agents"])
+        .current_dir(project.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    assert!(!project.path().join("AGENTS.md").exists());
     assert!(
         !project.path().join("CLAUDE.md").exists(),
         "CLAUDE.md should not exist without AGENTS.md"

--- a/tests/init_agents_integration.rs
+++ b/tests/init_agents_integration.rs
@@ -1,0 +1,214 @@
+//! Integration tests for `ion init`'s AGENTS.md handling.
+//!
+//! `ion init` should, by default and in every channel (interactive, piped,
+//! `--json`), ensure the project has an ion-managed AGENTS.md: create one from
+//! a detected language template (or a generic fallback) when none exists, and
+//! migrate an existing CLAUDE.md into AGENTS.md. `--no-agents` opts out.
+
+use std::process::Command;
+
+fn ion_cmd() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_ion"))
+}
+
+/// A fresh project with no recognizable language files gets a generic AGENTS.md.
+#[test]
+fn init_creates_generic_agents_md_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = ion_cmd()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+
+    // stdout must be a single, pure JSON object (no leaked progress lines).
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("init stdout should be pure JSON");
+    assert_eq!(parsed["success"], true);
+    assert_eq!(parsed["data"]["agents_md"]["action"], "created");
+    assert_eq!(parsed["data"]["agents_md"]["template"], "builtin:generic");
+
+    assert!(
+        dir.path().join("AGENTS.md").exists(),
+        "AGENTS.md should be created for a generic project"
+    );
+}
+
+/// Even piped (no TTY), a fresh init writes AGENTS.md — the behavior is not
+/// gated on an interactive terminal.
+#[test]
+fn init_creates_agents_md_piped() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = ion_cmd()
+        .args(["init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(dir.path().join("AGENTS.md").exists());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("AGENTS.md"),
+        "human output should mention AGENTS.md:\n{stdout}"
+    );
+}
+
+/// A detected language (Cargo.toml → rust) picks the matching built-in template.
+#[test]
+fn init_detects_language_template() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("Cargo.toml"), "[package]\nname = \"x\"\n").unwrap();
+    let output = ion_cmd()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("pure JSON");
+    assert_eq!(parsed["data"]["agents_md"]["template"], "builtin:rust");
+}
+
+/// An existing CLAUDE.md (real content, no AGENTS.md) is migrated to AGENTS.md
+/// with CLAUDE.md left as a symlink — even non-interactively.
+#[test]
+fn init_migrates_existing_claude_md_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("CLAUDE.md"),
+        "# House rules\n\nAlways write tests first.\n",
+    )
+    .unwrap();
+
+    let output = ion_cmd()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0), "init should succeed");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("pure JSON");
+    assert_eq!(parsed["data"]["agents_md"]["action"], "migrated");
+
+    // AGENTS.md now holds the old CLAUDE.md content.
+    let agents = std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
+    assert!(agents.contains("Always write tests first."));
+
+    // CLAUDE.md is now a symlink to AGENTS.md.
+    let meta = std::fs::symlink_metadata(dir.path().join("CLAUDE.md")).unwrap();
+    assert!(
+        meta.is_symlink(),
+        "CLAUDE.md should be a symlink after migration"
+    );
+}
+
+/// An existing AGENTS.md (no CLAUDE.md) is left intact and CLAUDE.md is linked
+/// to it — no template is attached to the user's own content.
+#[test]
+fn init_existing_agents_md_links_claude() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("AGENTS.md"), "# My own instructions\n").unwrap();
+
+    let output = ion_cmd()
+        .args(["init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    // Content untouched.
+    let agents = std::fs::read_to_string(dir.path().join("AGENTS.md")).unwrap();
+    assert!(agents.contains("My own instructions"));
+
+    // CLAUDE.md linked to AGENTS.md.
+    let meta = std::fs::symlink_metadata(dir.path().join("CLAUDE.md")).unwrap();
+    assert!(meta.is_symlink(), "CLAUDE.md should link to AGENTS.md");
+
+    // No template tracking attached to hand-written content.
+    let manifest = std::fs::read_to_string(dir.path().join("Ion.toml")).unwrap();
+    assert!(
+        !manifest.contains("[agents]"),
+        "should not attach a template to an existing hand-written AGENTS.md:\n{manifest}"
+    );
+}
+
+/// Both AGENTS.md and CLAUDE.md have real content → conflict is skipped safely
+/// (neither file is destroyed) in non-interactive mode.
+#[test]
+fn init_agents_conflict_skipped_json() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("AGENTS.md"), "# Agents\n\nA.\n").unwrap();
+    std::fs::write(dir.path().join("CLAUDE.md"), "# Claude\n\nB.\n").unwrap();
+
+    let output = ion_cmd()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("pure JSON");
+    assert_eq!(parsed["data"]["agents_md"]["action"], "skipped");
+
+    // CLAUDE.md must remain a real file with its content.
+    let meta = std::fs::symlink_metadata(dir.path().join("CLAUDE.md")).unwrap();
+    assert!(
+        !meta.is_symlink(),
+        "conflicting CLAUDE.md must be preserved"
+    );
+    let claude = std::fs::read_to_string(dir.path().join("CLAUDE.md")).unwrap();
+    assert!(claude.contains("B."));
+}
+
+/// After creating AGENTS.md from a template, init prompts the human/agent to
+/// fill it in — in both the human text and the JSON `next` array.
+#[test]
+fn init_prompts_to_fill_in_agents_md() {
+    // Human channel.
+    let dir = tempfile::tempdir().unwrap();
+    let output = ion_cmd()
+        .args(["init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("AGENTS.md") && stdout.contains("Fill in"),
+        "human output should prompt to fill in AGENTS.md:\n{stdout}"
+    );
+
+    // Agent channel.
+    let dir2 = tempfile::tempdir().unwrap();
+    let output = ion_cmd()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir2.path())
+        .output()
+        .unwrap();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    let next = parsed["data"]["next"].as_array().unwrap();
+    assert!(
+        next.iter()
+            .any(|s| s.as_str().is_some_and(|s| s.contains("AGENTS.md"))),
+        "JSON next steps should include filling in AGENTS.md: {next:?}"
+    );
+}
+
+/// `--no-agents` opts out of all AGENTS.md handling.
+#[test]
+fn init_no_agents_flag_skips_creation() {
+    let dir = tempfile::tempdir().unwrap();
+    let output = ion_cmd()
+        .args(["init", "--target", "claude", "--no-agents"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        !dir.path().join("AGENTS.md").exists(),
+        "--no-agents should not create AGENTS.md"
+    );
+}

--- a/tests/json_integration.rs
+++ b/tests/json_integration.rs
@@ -71,6 +71,30 @@ fn json_init_with_targets_succeeds() {
 }
 
 #[test]
+fn json_init_includes_next_steps() {
+    // After a fresh init the agent should be told, in the JSON envelope, what to
+    // do next — not just what was created. A fresh project (only the built-in
+    // ion-cli registered) should point at adding the first skill.
+    let dir = tempfile::tempdir().unwrap();
+    let output = ion()
+        .args(["--json", "init", "--target", "claude"])
+        .current_dir(dir.path())
+        .output()
+        .unwrap();
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    let next = parsed["data"]["next"]
+        .as_array()
+        .expect("data.next should be an array of next-step commands");
+    assert!(
+        next.iter()
+            .any(|c| c.as_str().is_some_and(|s| s.contains("ion add"))),
+        "fresh init should suggest `ion add` as the next step, got: {next:?}"
+    );
+}
+
+#[test]
 fn json_remove_without_yes_returns_action_required() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::write(

--- a/tests/scenario_tests.rs
+++ b/tests/scenario_tests.rs
@@ -443,6 +443,43 @@ fn init_with_target_flag_pty() {
 }
 
 #[test]
+fn init_prints_next_step_hint() {
+    // A human finishing `init` should be told the natural next move, not left at
+    // a bare file-list confirmation.
+    let tmp = tempfile::tempdir().unwrap();
+    let output = ion()
+        .args(["init", "-t", "claude"])
+        .current_dir(tmp.path())
+        .run()
+        .unwrap();
+    assert!(output.success());
+    let stdout = output.stdout();
+    assert!(
+        stdout.contains("Next") && stdout.contains("ion add"),
+        "init should print a next-step hint naming `ion add`:\n{stdout}"
+    );
+}
+
+#[test]
+fn init_no_tty_marks_detected_targets() {
+    // In a repo that already has a `.claude/` directory, the no-TTY target list
+    // shown to a human should mark that target as detected — mirroring the
+    // `detected` flag the --json channel already exposes.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let output = ion().args(["init"]).current_dir(tmp.path()).run().unwrap();
+    assert!(
+        !output.success(),
+        "no target + no TTY should be a soft error"
+    );
+    let stdout = output.stdout();
+    assert!(
+        stdout.contains("claude") && stdout.contains("detected"),
+        "human target list should mark detected targets:\n{stdout}"
+    );
+}
+
+#[test]
 fn init_json_without_target_action_required() {
     let tmp = tempfile::tempdir().unwrap();
     let output = ion()


### PR DESCRIPTION
## What

Dogfooding `ion init` on a real project (bloqade-website) surfaced two progressive-prompting gaps on the init journey. Both are fixed here, test-first.

### 1. `init` ended with no next step (both channels)
The old output stopped at `Created Ion.toml with N target(s)` — a dead end for a human *and* an agent. Now a single, state-aware next-step line renders from one source of truth to **both** channels:

- fresh project → `ion add <source>` / `ion search <query>`
- skills already declared → `ion add`

The `--json` envelope gained a `data.next` array:
```json
"next": ["ion add <source>", "ion search <query>"]
```

### 2. No-TTY `init` told the agent more than the human (channel mismatch)
`--json` exposed a per-target `"detected": true` flag, but the human plain-text list showed nothing and hard-coded `--target claude` in the recovery example. Now the human list marks `(detected)` and prefers a detected target in the example:
```
Available targets:
  claude -> .claude/skills (detected)
  cursor -> .cursor/skills
  windsurf -> .windsurf/skills
Re-run with --target <name> to select targets (e.g. --target claude).
```

## Changes
- `src/commands/init.rs` — next-step helpers (`next_steps_after_init`) + `(detected)` marking
- `src/builtin_skill.rs` — expose `SKILL_NAME` so the next-step counter excludes the Ion-managed builtin
- `tests/json_integration.rs`, `tests/scenario_tests.rs` — three failing-first tests pinning the guidance in both channels
- `skills/dogfooding-ion/SKILL.md` — logged the second-pass findings

## Notes
`ion-cli = { type = "local" }` is intentional (skipped by fetch/validate/update, refreshed via `refresh_global`) — documented, not changed.

## Test plan
- `cargo fmt --all` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo nextest run` — 800/800 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)